### PR TITLE
Export domain details as JSON

### DIFF
--- a/omDomainJSON.py
+++ b/omDomainJSON.py
@@ -1,0 +1,77 @@
+#
+# Copyright 2023 The Superpower Institute Ltd.
+#
+# This file is part of OpenMethane.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Generate a JSON file describing the domain and grid.
+"""
+
+import numpy as np
+import netCDF4 as nc
+from omInputs import domainXr, domainProj
+from omOutputs import domainJSONOutputPath
+import json
+
+def makePoint(x, y):
+    return ([float(x), float(y)])
+
+def writeDomainJSON():
+    # Load raster land-use data
+    print("converting domain grid details to JSON")
+
+    domain = {
+        "crs": {
+            "projection_type": "lambert_conformal_conic",
+            "standard_parallel": float(domainXr.attrs['TRUELAT1']),
+            "standard_parallel_2": float(domainXr.attrs['TRUELAT2']),
+            "longitude_of_central_meridian": float(domainXr.attrs['STAND_LON']),
+            "latitude_of_projection_origin": float(domainXr.attrs['MOAD_CEN_LAT']),
+            "proj4": domainProj.to_proj4(),
+        },
+        "grid_properties": {
+            "rows": domainXr.sizes['ROW'],
+            "cols": domainXr.sizes['COL'],
+            "cell_x_size": float(domainXr.attrs['DX']),
+            "cell_y_size": float(domainXr.attrs['DY']),
+        },
+        "grid_cells": [],
+    };
+
+    if domainXr.sizes['ROW_D'] != domainXr.sizes['ROW'] + 1 or domainXr.sizes['COL_D'] != domainXr.sizes['COL'] + 1:
+      raise Exception('Cell corners dimension must be one greater than number of cells')
+
+    # Add projection coordinates and WGS84 lat/lon for each grid cell
+    for (y, x), _ in np.ndenumerate(domainXr["LANDMASK"][0]):
+        cell_properties = {
+            "projection_x_coordinate": int(x),
+            "projection_y_coordinate": int(y),
+            "landmask": int(domainXr["LANDMASK"].item(0, y, x)),
+            "center_latlon": makePoint(domainXr["LAT"].item(0, y, x), domainXr["LON"].item(0, y, x)),
+            "corner_latlons": [
+              makePoint(domainXr["LATD"].item(0, 0, y, x),         domainXr["LOND"].item(0, 0, y, x)),
+              makePoint(domainXr["LATD"].item(0, 0, y, x + 1),     domainXr["LOND"].item(0, 0, y, x + 1)),
+              makePoint(domainXr["LATD"].item(0, 0, y + 1, x + 1), domainXr["LOND"].item(0, 0, y + 1, x + 1)),
+              makePoint(domainXr["LATD"].item(0, 0, y + 1, x),     domainXr["LOND"].item(0, 0, y + 1, x)),
+            ],
+        }
+        domain["grid_cells"].append(cell_properties);
+
+    with open(domainJSONOutputPath, "w") as fp:
+        json.dump(domain, fp)
+
+if __name__ == '__main__':
+    writeDomainJSON()

--- a/scripts/omCreateDomainInfo.py
+++ b/scripts/omCreateDomainInfo.py
@@ -42,7 +42,10 @@ with xr.open_dataset( os.path.join(root_path, croFilePath)) as croXr:
 
 with xr.open_dataset( os.path.join(root_path, dotFilePath)) as dotXr:
     # some repetition between the geom and grid files here, XCELL=DX and YCELL=DY
-    for attr in ['XCELL', 'YCELL']:
+    # - XCELL, YCELL: size of a single cell in m
+    # - XCENT, YCENT: lat/long of grid centre point
+    # - XORIG, YORIG: position of 0,0 cell in grid coordinates (in m)
+    for attr in ['XCELL', 'YCELL', 'XCENT', 'YCENT', 'XORIG', 'YORIG']:
         domainXr.attrs[attr] = croXr.attrs[attr]
     for var in ['LATD','LOND']:
         domainXr[var] = dotXr[var].rename({'COL':'COL_D', 'ROW':'ROW_D'})

--- a/scripts/omDomainJSON.py
+++ b/scripts/omDomainJSON.py
@@ -71,7 +71,7 @@ def write_domain_json(output_file):
               make_point(domainXr["LATD"].item(0, 0, y + 1, x),     domainXr["LOND"].item(0, 0, y + 1, x)),
             ],
         }
-        domain["grid_cells"].append(cell_properties);
+        domain["grid_cells"].append(cell_properties)
 
     json.dump(domain, output_file)
 

--- a/scripts/omDomainJSON.py
+++ b/scripts/omDomainJSON.py
@@ -21,9 +21,8 @@ Generate a JSON file describing the domain and grid.
 """
 
 import numpy as np
-import netCDF4 as nc
-from omInputs import domainXr, domainProj
-from omOutputs import domainJSONOutputPath
+from openmethane_prior.omInputs import domainXr, domainProj
+from openmethane_prior.omOutputs import domainJSONOutputPath
 import json
 
 def makePoint(x, y):

--- a/scripts/omDomainJSON.py
+++ b/scripts/omDomainJSON.py
@@ -52,7 +52,7 @@ def write_domain_json(output_file):
             "center_latlon": make_point(domainXr.attrs['XCENT'], domainXr.attrs['YCENT']),
         },
         "grid_cells": [],
-    };
+    }
 
     if domainXr.sizes['ROW_D'] != domainXr.sizes['ROW'] + 1 or domainXr.sizes['COL_D'] != domainXr.sizes['COL'] + 1:
       raise RuntimeError('Cell corners dimension must be one greater than number of cells')

--- a/scripts/omDomainJSON.py
+++ b/scripts/omDomainJSON.py
@@ -21,7 +21,6 @@ Generate a JSON file describing the domain and grid.
 """
 
 import numpy as np
-import netCDF4 as nc
 from openmethane_prior.omInputs import domainXr, domainProj
 from openmethane_prior.omOutputs import domainJSONOutputPath
 import json

--- a/scripts/omDomainJSON.py
+++ b/scripts/omDomainJSON.py
@@ -25,10 +25,10 @@ from openmethane_prior.omInputs import domainXr, domainProj
 from openmethane_prior.omOutputs import domainJSONOutputPath
 import json
 
-def makePoint(x, y):
+def make_point(x, y):
     return ([float(x), float(y)])
 
-def writeDomainJSON():
+def write_domain_json(output_file):
     # Load raster land-use data
     print("converting domain grid details to JSON")
 
@@ -59,18 +59,18 @@ def writeDomainJSON():
             "projection_x_coordinate": int(x),
             "projection_y_coordinate": int(y),
             "landmask": int(domainXr["LANDMASK"].item(0, y, x)),
-            "center_latlon": makePoint(domainXr["LAT"].item(0, y, x), domainXr["LON"].item(0, y, x)),
+            "center_latlon": make_point(domainXr["LAT"].item(0, y, x), domainXr["LON"].item(0, y, x)),
             "corner_latlons": [
-              makePoint(domainXr["LATD"].item(0, 0, y, x),         domainXr["LOND"].item(0, 0, y, x)),
-              makePoint(domainXr["LATD"].item(0, 0, y, x + 1),     domainXr["LOND"].item(0, 0, y, x + 1)),
-              makePoint(domainXr["LATD"].item(0, 0, y + 1, x + 1), domainXr["LOND"].item(0, 0, y + 1, x + 1)),
-              makePoint(domainXr["LATD"].item(0, 0, y + 1, x),     domainXr["LOND"].item(0, 0, y + 1, x)),
+              make_point(domainXr["LATD"].item(0, 0, y, x),         domainXr["LOND"].item(0, 0, y, x)),
+              make_point(domainXr["LATD"].item(0, 0, y, x + 1),     domainXr["LOND"].item(0, 0, y, x + 1)),
+              make_point(domainXr["LATD"].item(0, 0, y + 1, x + 1), domainXr["LOND"].item(0, 0, y + 1, x + 1)),
+              make_point(domainXr["LATD"].item(0, 0, y + 1, x),     domainXr["LOND"].item(0, 0, y + 1, x)),
             ],
         }
         domain["grid_cells"].append(cell_properties);
 
-    with open(domainJSONOutputPath, "w") as fp:
-        json.dump(domain, fp)
+    json.dump(domain, output_file)
 
 if __name__ == '__main__':
-    writeDomainJSON()
+    with open(domainJSONOutputPath, "w") as fp:
+        write_domain_json(fp)

--- a/scripts/omDomainJSON.py
+++ b/scripts/omDomainJSON.py
@@ -56,18 +56,19 @@ def write_domain_json(output_file):
     if domainXr.sizes['ROW_D'] != domainXr.sizes['ROW'] + 1 or domainXr.sizes['COL_D'] != domainXr.sizes['COL'] + 1:
       raise RuntimeError('Cell corners dimension must be one greater than number of cells')
 
+    domain_slice = domainXr.sel(TSTEP=0, LAY=0)
     # Add projection coordinates and WGS84 lat/lon for each grid cell
-    for (y, x), _ in np.ndenumerate(domainXr["LANDMASK"][0]):
+    for (y, x), _ in np.ndenumerate(domain_slice["LANDMASK"]):
         cell_properties = {
             "projection_x_coordinate": int(x),
             "projection_y_coordinate": int(y),
-            "landmask": int(domainXr["LANDMASK"].item(0, y, x)),
-            "center_latlon": make_point(domainXr["LAT"].item(0, y, x), domainXr["LON"].item(0, y, x)),
+            "landmask": int(domain_slice["LANDMASK"].item(y, x)),
+            "center_latlon": make_point(domain_slice["LAT"].item(y, x), domain_slice["LON"].item(y, x)),
             "corner_latlons": [
-              make_point(domainXr["LATD"].item(0, 0, y, x),         domainXr["LOND"].item(0, 0, y, x)),
-              make_point(domainXr["LATD"].item(0, 0, y, x + 1),     domainXr["LOND"].item(0, 0, y, x + 1)),
-              make_point(domainXr["LATD"].item(0, 0, y + 1, x + 1), domainXr["LOND"].item(0, 0, y + 1, x + 1)),
-              make_point(domainXr["LATD"].item(0, 0, y + 1, x),     domainXr["LOND"].item(0, 0, y + 1, x)),
+              make_point(domain_slice["LATD"].item(y, x),         domain_slice["LOND"].item(y, x)),
+              make_point(domain_slice["LATD"].item(y, x + 1),     domain_slice["LOND"].item(y, x + 1)),
+              make_point(domain_slice["LATD"].item(y + 1, x + 1), domain_slice["LOND"].item(y + 1, x + 1)),
+              make_point(domain_slice["LATD"].item(y + 1, x),     domain_slice["LOND"].item(y + 1, x)),
             ],
         }
         domain["grid_cells"].append(cell_properties)

--- a/scripts/omDomainJSON.py
+++ b/scripts/omDomainJSON.py
@@ -21,6 +21,7 @@ Generate a JSON file describing the domain and grid.
 """
 
 import numpy as np
+import netCDF4 as nc
 from openmethane_prior.omInputs import domainXr, domainProj
 from openmethane_prior.omOutputs import domainJSONOutputPath
 import json

--- a/scripts/omDomainJSON.py
+++ b/scripts/omDomainJSON.py
@@ -55,7 +55,7 @@ def write_domain_json(output_file):
     };
 
     if domainXr.sizes['ROW_D'] != domainXr.sizes['ROW'] + 1 or domainXr.sizes['COL_D'] != domainXr.sizes['COL'] + 1:
-      raise Exception('Cell corners dimension must be one greater than number of cells')
+      raise RuntimeError('Cell corners dimension must be one greater than number of cells')
 
     # Add projection coordinates and WGS84 lat/lon for each grid cell
     for (y, x), _ in np.ndenumerate(domainXr["LANDMASK"][0]):

--- a/scripts/omDomainJSON.py
+++ b/scripts/omDomainJSON.py
@@ -40,6 +40,8 @@ def write_domain_json(output_file):
             "standard_parallel_2": float(domainXr.attrs['TRUELAT2']),
             "longitude_of_central_meridian": float(domainXr.attrs['STAND_LON']),
             "latitude_of_projection_origin": float(domainXr.attrs['MOAD_CEN_LAT']),
+            "projection_origin_x": float(domainXr.attrs['XORIG']),
+            "projection_origin_y": float(domainXr.attrs['YORIG']),
             "proj4": domainProj.to_proj4(),
         },
         "grid_properties": {
@@ -47,6 +49,7 @@ def write_domain_json(output_file):
             "cols": domainXr.sizes['COL'],
             "cell_x_size": float(domainXr.attrs['DX']),
             "cell_y_size": float(domainXr.attrs['DY']),
+            "center_latlon": make_point(domainXr.attrs['XCENT'], domainXr.attrs['YCENT']),
         },
         "grid_cells": [],
     };

--- a/scripts/omGeoJSON.py
+++ b/scripts/omGeoJSON.py
@@ -40,9 +40,9 @@ def processGeoJSON():
     print("Loading output file")
     ds = nc.Dataset(domainOutputPath)
     landmask = ds["LANDMASK"][:]
-    lats = ds["XLAT_C"][:]
-    longs = ds["XLONG_C"][:]
-    ch4 = ds["OCH4_TOTAL"][:][0]
+    lats = ds["LATD"][:][0]
+    longs = ds["LOND"][:][0]
+    ch4 = ds["OCH4_TOTAL"][:][0][0]
     maxEmission = np.amax(ch4)
 
     # Add GeoJSON Polygon feature for each grid location

--- a/src/openmethane_prior/omInputs.py
+++ b/src/openmethane_prior/omInputs.py
@@ -80,8 +80,9 @@ if os.path.exists(domainPath):
             lat_2=domainXr.TRUELAT2,
             lat_0=domainXr.MOAD_CEN_LAT,
             lon_0=domainXr.STAND_LON,
-            x_0=domainXr.XORIG,
-            y_0=domainXr.YORIG,
+            # https://github.com/openmethane/openmethane-prior/issues/24
+            # x_0=domainXr.XORIG,
+            # y_0=domainXr.YORIG,
             a=6370000,
             b=6370000,
         )

--- a/src/openmethane_prior/omInputs.py
+++ b/src/openmethane_prior/omInputs.py
@@ -74,7 +74,17 @@ domainProj = None
 if os.path.exists(domainPath):
     with xr.open_dataset(domainPath) as dss:
         domainXr = dss.load()
-        domainProj = pyproj.Proj(proj='lcc', lat_1=domainXr.TRUELAT1, lat_2=domainXr.TRUELAT2, lat_0=domainXr.MOAD_CEN_LAT, lon_0=domainXr.STAND_LON, a=6370000, b=6370000)
+        domainProj = pyproj.Proj(
+            proj='lcc',
+            lat_1=domainXr.TRUELAT1,
+            lat_2=domainXr.TRUELAT2,
+            lat_0=domainXr.MOAD_CEN_LAT,
+            lon_0=domainXr.STAND_LON,
+            x_0=domainXr.XORIG,
+            y_0=domainXr.YORIG,
+            a=6370000,
+            b=6370000,
+        )
 
 def checkInputFile(file, errorMsg, errors):
     ## Check that all required input files are present

--- a/src/openmethane_prior/omOutputs.py
+++ b/src/openmethane_prior/omOutputs.py
@@ -38,6 +38,7 @@ domainFilename = getenv("DOMAIN")
 landuseReprojectionPath = os.path.join(intermediatesPath, "land-use.tif")
 ntlReprojectionPath = os.path.join(intermediatesPath, "night-time-lights.tif")
 domainOutputPath = os.path.join(outputsPath, f"out-{domainFilename}")
+domainJSONOutputPath = os.path.join(outputsPath, "om-domain.json")
 geoJSONOutputPath = os.path.join(outputsPath, "grid-cells.json")
 ch4JSONOutputPath = os.path.join(outputsPath, "methane.json")
 

--- a/tests/test_domain_json.py
+++ b/tests/test_domain_json.py
@@ -1,0 +1,61 @@
+# work around until folder structure is updated
+import os
+import sys
+# insert root directory into python module search path
+sys.path.insert(1, os.getcwd())
+
+from io import StringIO
+import json
+from pathlib import Path
+
+from openmethane_prior.omInputs import domainPath
+from scripts.omDomainJSON import write_domain_json
+
+ROOT_DIRECTORY = Path(__file__).parent.parent
+
+def test_001_domain_file() :
+    # domain file has to have been created with omCreateDomainInfo.py
+    # before the domain JSON script will work
+    assert os.path.isfile(domainPath)
+
+def test_002_json_structure() :
+    outfile = StringIO()
+    
+    # generate the JSON, writing to a memory buffer
+    write_domain_json(outfile)
+
+    outfile.seek(0);
+    domain = json.load(outfile)
+
+    # spot check some known values
+    assert domain["crs"] == {
+        "projection_type": "lambert_conformal_conic",
+        "standard_parallel": -15.0,
+        "standard_parallel_2": -40.0,
+        "longitude_of_central_meridian": 133.302001953125,
+        "latitude_of_projection_origin": -27.643997192382812,
+        "proj4": "+proj=lcc +lat_0=-27.6439971923828 +lon_0=133.302001953125 +lat_1=-15 +lat_2=-40 +x_0=0 +y_0=0 +R=6370000 +units=m +no_defs"
+    }
+    assert domain["grid_properties"] == {
+        "rows": 430,
+        "cols": 454,
+        "cell_x_size": 10000.0,
+        "cell_y_size": 10000.0,
+    }
+
+    # Check the number of cells
+    assert len(domain["grid_cells"]) == domain["grid_properties"]["rows"] * domain["grid_properties"]["cols"];
+
+    # check a single grid cell for known values
+    assert domain["grid_cells"][0] == {
+        "projection_x_coordinate": 0,
+        "projection_y_coordinate": 0,
+        "landmask": 0,
+        "center_latlon": [-44.73386001586914, 105.03723907470703],
+        "corner_latlons": [
+            [-44.76662826538086, 104.96293640136719],
+            [-44.78663635253906, 105.08344268798828],
+            [-44.70106506347656, 105.11154174804688],
+            [-44.681068420410156, 104.99114990234375],
+        ]
+    }

--- a/tests/test_domain_json.py
+++ b/tests/test_domain_json.py
@@ -7,18 +7,16 @@ sys.path.insert(1, os.getcwd())
 from io import StringIO
 import json
 from pathlib import Path
+import pytest
 
 from openmethane_prior.omInputs import domainPath
 from scripts.omDomainJSON import write_domain_json
 
 ROOT_DIRECTORY = Path(__file__).parent.parent
 
-def test_001_domain_file() :
-    # domain file has to have been created with omCreateDomainInfo.py
-    # before the domain JSON script will work
-    assert os.path.isfile(domainPath)
-
-def test_002_json_structure() :
+@pytest.mark.skipif(os.path.isfile(domainPath) != True,
+                    reason="test requires omCreateDomainInfo.py to have been run")
+def test_001_json_structure() :
     outfile = StringIO()
     
     # generate the JSON, writing to a memory buffer

--- a/tests/test_domain_json.py
+++ b/tests/test_domain_json.py
@@ -32,13 +32,16 @@ def test_001_json_structure() :
         "standard_parallel_2": -40.0,
         "longitude_of_central_meridian": 133.302001953125,
         "latitude_of_projection_origin": -27.643997192382812,
-        "proj4": "+proj=lcc +lat_0=-27.6439971923828 +lon_0=133.302001953125 +lat_1=-15 +lat_2=-40 +x_0=0 +y_0=0 +R=6370000 +units=m +no_defs"
+        "projection_origin_x": -2270000,
+        "projection_origin_y": -2165629.25,
+        "proj4": "+proj=lcc +lat_0=-27.6439971923828 +lon_0=133.302001953125 +lat_1=-15 +lat_2=-40 +x_0=-2270000 +y_0=-2165629.25 +R=6370000 +units=m +no_defs"
     }
     assert domain["grid_properties"] == {
         "rows": 430,
         "cols": 454,
         "cell_x_size": 10000.0,
         "cell_y_size": 10000.0,
+        "center_latlon": [133.302001953125, -27.5],
     }
 
     # Check the number of cells

--- a/tests/test_domain_json.py
+++ b/tests/test_domain_json.py
@@ -34,7 +34,7 @@ def test_001_json_structure() :
         "latitude_of_projection_origin": -27.643997192382812,
         "projection_origin_x": -2270000,
         "projection_origin_y": -2165629.25,
-        "proj4": "+proj=lcc +lat_0=-27.6439971923828 +lon_0=133.302001953125 +lat_1=-15 +lat_2=-40 +x_0=-2270000 +y_0=-2165629.25 +R=6370000 +units=m +no_defs"
+        "proj4": "+proj=lcc +lat_0=-27.6439971923828 +lon_0=133.302001953125 +lat_1=-15 +lat_2=-40 +x_0=0 +y_0=0 +R=6370000 +units=m +no_defs"
     }
     assert domain["grid_properties"] == {
         "rows": 430,


### PR DESCRIPTION
## Description

Add a `omDomainJSON.py` script to read all the details of the domain, projection and grid from the domain NetCDFv4 file, and export them to JSON.

In an ideal world, JavaScript projects could read the NetCDFv4 domain file directly. Unfortunately, it seems that there is very little support for NetCDFv4 files in the JavaScript ecosystem. Exporting as a custom JSON file isn't ideal, but is a quick way to make the data available.

Although this data is not specific to the prior, it seemed best to co-locate this script with the `omCreateDomainInfo.py` script which is where the data comes from.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
<!--- Below to be added back once we have a changelog --> 
<!--- - [ ] Changelog item added to `changelog/`) -->

## Notes
