### PR TITLE
Export all layers of the prior in omGeoJSON.py

### DIFF
--- a/scripts/omGeoJSON.py
+++ b/scripts/omGeoJSON.py
@@ -91,7 +91,7 @@ def processGeoJSON():
             # raw values
             properties[layer_name] = float(ds_slice[layer_name][y][x])
             # relative to max
-            properties[f"{layer_name}_R"] =  float(ds_slice[layer_name][y][x] / max_values[layer_name]),
+            properties[f"{layer_name}_R"] = float(ds_slice[layer_name][y][x] / max_values[layer_name])
 
         features.append(
             Feature(

--- a/scripts/omGeoJSON.py
+++ b/scripts/omGeoJSON.py
@@ -72,7 +72,7 @@ def processGeoJSON():
         # extract the meaningful dimensions from the NetCDF variables
         ds_slice[layer_name] = ds[layer_name][:][0][0]
         # find the max emission value in a single cell for each layer
-        max_values[layer_name] = np.amax(ds_slice[layer_name])
+        max_values[layer_name] = np.max(ds_slice[layer_name])
 
     # Add GeoJSON Polygon feature for each grid location
     features = []

--- a/scripts/omGeoJSON.py
+++ b/scripts/omGeoJSON.py
@@ -23,7 +23,7 @@ import json
 import netCDF4 as nc
 import numpy as np
 from geojson import Feature, FeatureCollection, Polygon, dumps
-from omOutputs import ch4JSONOutputPath, domainOutputPath, geoJSONOutputPath
+from openmethane_prior.omOutputs import domainOutputPath, geoJSONOutputPath
 
 
 class NumpyEncoder(json.JSONEncoder):
@@ -42,47 +42,110 @@ def processGeoJSON():
     # Load domain
     print("Loading output file")
     ds = nc.Dataset(domainOutputPath)
-    landmask = ds["LANDMASK"][:]
-    lats = ds["LATD"][:][0]
-    longs = ds["LOND"][:][0]
-    ch4 = ds["OCH4_TOTAL"][:][0][0]
-    maxEmission = np.amax(ch4)
+
+    # There is a better way to do this but this will work for now
+    # Using xarray wasn't straightforward because the layers don't use
+    # the same attribute names, ie mixing x/y and lat/long.
+    ds_slice = {
+        "LANDMASK": ds["LANDMASK"][:][0],
+        "LATD": ds["LATD"][:][0][0],
+        "LOND": ds["LOND"][:][0][0],
+
+        "OCH4_AGRICULTURE": ds["OCH4_AGRICULTURE"][:][0][0],
+        "OCH4_LULUCF": ds["OCH4_LULUCF"][:][0][0],
+        "OCH4_WASTE": ds["OCH4_WASTE"][:][0][0],
+        "OCH4_LIVESTOCK": ds["OCH4_LIVESTOCK"][:][0][0],
+        "OCH4_INDUSTRIAL": ds["OCH4_INDUSTRIAL"][:][0][0],
+        "OCH4_STATIONARY": ds["OCH4_STATIONARY"][:][0][0],
+        "OCH4_TRANSPORT": ds["OCH4_TRANSPORT"][:][0][0],
+        "OCH4_ELECTRICITY": ds["OCH4_ELECTRICITY"][:][0][0],
+        "OCH4_FUGITIVE": ds["OCH4_FUGITIVE"][:][0][0],
+        "OCH4_TERMITE": ds["OCH4_TERMITE"][:][0][0],
+        "OCH4_FIRE": ds["OCH4_FIRE"][:][0][0],
+        "OCH4_WETLANDS": ds["OCH4_WETLANDS"][:][0][0],
+        "OCH4_TOTAL": ds["OCH4_TOTAL"][:][0][0],
+    }
+
+    print("Finding max emission for each layer")
+    max_values = {
+        "OCH4_AGRICULTURE": np.amax(ds_slice["OCH4_AGRICULTURE"]),
+        "OCH4_LULUCF": np.amax(ds_slice["OCH4_LULUCF"]),
+        "OCH4_WASTE": np.amax(ds_slice["OCH4_WASTE"]),
+        "OCH4_LIVESTOCK": np.amax(ds_slice["OCH4_LIVESTOCK"]),
+        "OCH4_INDUSTRIAL": np.amax(ds_slice["OCH4_INDUSTRIAL"]),
+        "OCH4_STATIONARY": np.amax(ds_slice["OCH4_STATIONARY"]),
+        "OCH4_TRANSPORT": np.amax(ds_slice["OCH4_TRANSPORT"]),
+        "OCH4_ELECTRICITY": np.amax(ds_slice["OCH4_ELECTRICITY"]),
+        "OCH4_FUGITIVE": np.amax(ds_slice["OCH4_FUGITIVE"]),
+        "OCH4_TERMITE": np.amax(ds_slice["OCH4_TERMITE"]),
+        "OCH4_FIRE": np.amax(ds_slice["OCH4_FIRE"]),
+        "OCH4_WETLANDS": np.amax(ds_slice["OCH4_WETLANDS"]),
+        "OCH4_TOTAL": np.amax(ds_slice["OCH4_TOTAL"]),
+    }
 
     # Add GeoJSON Polygon feature for each grid location
-    methane = np.zeros((landmask.shape[1], landmask.shape[2]), dtype=np.int32)
     features = []
 
-    for (y, x), _ in np.ndenumerate(landmask[0]):
-        methane[y][x] = ch4[y][x]
+    print("Gathering cell data")
+    for (y, x), _ in np.ndenumerate(ds_slice["LANDMASK"]):
         features.append(
             Feature(
-                # TODO: check if this it too nested
                 geometry=Polygon(
                     (
                         [
-                            (float(longs[0][y][x]), float(lats[0][y][x])),
-                            (float(longs[0][y][x + 1]), float(lats[0][y][x + 1])),
-                            (float(longs[0][y + 1][x + 1]), float(lats[0][y + 1][x + 1])),
-                            (float(longs[0][y + 1][x]), float(lats[0][y + 1][x])),
-                            (float(longs[0][y][x]), float(lats[0][y][x])),
+                            (float(ds_slice["LOND"][y][x]), float(ds_slice["LATD"][y][x])),
+                            (float(ds_slice["LOND"][y][x + 1]), float(ds_slice["LATD"][y][x + 1])),
+                            (float(ds_slice["LOND"][y + 1][x + 1]), float(ds_slice["LATD"][y + 1][x + 1])),
+                            (float(ds_slice["LOND"][y + 1][x]), float(ds_slice["LATD"][y + 1][x])),
+                            (float(ds_slice["LOND"][y][x]), float(ds_slice["LATD"][y][x])),
                         ],
                     )
                 ),
                 properties={
                     "x": x,
                     "y": y,
-                    "m": float(methane[y][x]),
-                    "rm": float(methane[y][x] / maxEmission * 100) if methane[y][x] >= 0 else 0,
+                    "landmask": int(ds_slice["LANDMASK"][y][x]),
+                    
+                    # raw values
+                    "OCH4_AGRICULTURE": float(ds_slice["OCH4_AGRICULTURE"][y][x]),
+                    "OCH4_LULUCF": float(ds_slice["OCH4_LULUCF"][y][x]),
+                    "OCH4_WASTE": float(ds_slice["OCH4_WASTE"][y][x]),
+                    "OCH4_LIVESTOCK": float(ds_slice["OCH4_LIVESTOCK"][y][x]),
+                    "OCH4_INDUSTRIAL": float(ds_slice["OCH4_INDUSTRIAL"][y][x]),
+                    "OCH4_STATIONARY": float(ds_slice["OCH4_STATIONARY"][y][x]),
+                    "OCH4_TRANSPORT": float(ds_slice["OCH4_TRANSPORT"][y][x]),
+                    "OCH4_ELECTRICITY": float(ds_slice["OCH4_ELECTRICITY"][y][x]),
+                    "OCH4_FUGITIVE": float(ds_slice["OCH4_FUGITIVE"][y][x]),
+                    "OCH4_TERMITE": float(ds_slice["OCH4_TERMITE"][y][x]),
+                    "OCH4_FIRE": float(ds_slice["OCH4_FIRE"][y][x]),
+                    "OCH4_WETLANDS": float(ds_slice["OCH4_WETLANDS"][y][x]),
+                    "OCH4_TOTAL": float(ds_slice["OCH4_TOTAL"][y][x]),
+                    "m": float(ds_slice["OCH4_TOTAL"][y][x]),
+
+                    # relative to max
+                    "OCH4_AGRICULTURE_R": float(ds_slice["OCH4_AGRICULTURE"][y][x] / max_values["OCH4_AGRICULTURE"]),
+                    "OCH4_LULUCF_R": float(ds_slice["OCH4_LULUCF"][y][x] / max_values["OCH4_LULUCF"]),
+                    "OCH4_WASTE_R": float(ds_slice["OCH4_WASTE"][y][x] / max_values["OCH4_WASTE"]),
+                    "OCH4_LIVESTOCK_R": float(ds_slice["OCH4_LIVESTOCK"][y][x] / max_values["OCH4_LIVESTOCK"]),
+                    "OCH4_INDUSTRIAL_R": float(ds_slice["OCH4_INDUSTRIAL"][y][x] / max_values["OCH4_INDUSTRIAL"]),
+                    "OCH4_STATIONARY_R": float(ds_slice["OCH4_STATIONARY"][y][x] / max_values["OCH4_STATIONARY"]),
+                    "OCH4_TRANSPORT_R": float(ds_slice["OCH4_TRANSPORT"][y][x] / max_values["OCH4_TRANSPORT"]),
+                    "OCH4_ELECTRICITY_R": float(ds_slice["OCH4_ELECTRICITY"][y][x] / max_values["OCH4_ELECTRICITY"]),
+                    "OCH4_FUGITIVE_R": float(ds_slice["OCH4_FUGITIVE"][y][x] / max_values["OCH4_FUGITIVE"]),
+                    "OCH4_TERMITE_R": float(ds_slice["OCH4_TERMITE"][y][x] / max_values["OCH4_TERMITE"]),
+                    "OCH4_FIRE_R": float(ds_slice["OCH4_FIRE"][y][x] / max_values["OCH4_FIRE"]),
+                    "OCH4_WETLANDS_R": float(ds_slice["OCH4_WETLANDS"][y][x] / max_values["OCH4_WETLANDS"]),
+                    "OCH4_TOTAL_R": float(ds_slice["OCH4_TOTAL"][y][x] / max_values["OCH4_TOTAL"]),
+                    "rm": float(ds_slice["OCH4_TOTAL"][y][x] / max_values["OCH4_TOTAL"]),
                 },
             )
         )
 
     feature_collection = FeatureCollection(features)
+
+    print("Writing output to", geoJSONOutputPath)
     with open(geoJSONOutputPath, "w") as fp:
         fp.write(dumps(feature_collection))
-
-    with open(ch4JSONOutputPath, "w") as fp:
-        json.dump(methane, fp, cls=NumpyEncoder)
 
 
 if __name__ == "__main__":

--- a/src/openmethane_prior/omOutputs.py
+++ b/src/openmethane_prior/omOutputs.py
@@ -34,8 +34,7 @@ landuseReprojectionPath = os.path.join(intermediatesPath, "land-use.tif")
 ntlReprojectionPath = os.path.join(intermediatesPath, "night-time-lights.tif")
 domainOutputPath = os.path.join(outputsPath, f"out-{domainFilename}")
 domainJSONOutputPath = os.path.join(outputsPath, "om-domain.json")
-geoJSONOutputPath = os.path.join(outputsPath, "grid-cells.json")
-ch4JSONOutputPath = os.path.join(outputsPath, "methane.json")
+geoJSONOutputPath = os.path.join(outputsPath, "om-prior.json")
 
 coordNames = ["TSTEP", "LAY", "ROW", "COL"]
 


### PR DESCRIPTION
## Description

This script is still just used as a debugging script, but exporting all layers gives us more data to debug with.

On one hand, we can visualise each layer distinctly in the front-end, allowing each layer to be checked visually. As a secondary benefit, each layer provides a distinct but realistic example of methane emissions that can be used as mock data for front-end development.

## Checklist

Please confirm that this pull request has done the following:

- [] ~~Tests added~~
- [] ~~Documentation added (where applicable)~~

Note: I have not added tests, as this file is still only useful for debugging and I do not believe it forms part of the production workflow.

## Notes

I attempted to update this script to work more like omDomainJSON.py which uses xarray to select the specific NetCDF layers we're interested in, however that approach wasn't easy because the variables in the prior output file don't all share the same dimensions.
