### PR TITLE
Migrate to ADS-beta

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -85,7 +85,7 @@ jobs:
           python -m pytest -r a -v tests/integration/test_domain_json.py
         env:
           CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
-          CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api/v2
+          CDSAPI_URL: https://ads-beta.atmosphere.copernicus.eu/api
 
   # Tag the latest image if running on the main branch
   # TODO: Handle tagged builds

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
          make test
         env:
           CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
-          CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api/v2
+          CDSAPI_URL: https://ads-beta.atmosphere.copernicus.eu/api
 
   imports-without-extras:
     strategy:

--- a/README.md
+++ b/README.md
@@ -8,20 +8,16 @@ This repository is matched with downloadable input data so that it will run out 
 
 Copy the `.env.example` file to `.env` and customise the paths as you need.
 
-In order to download the GFAS emissions data,
-credentials for the Copernicus Atmospheric Data Store (ADS) API are required.
-Instructions for registering for the ADS API and setting up the credentials are provided
-at in [ADS Docs](https://ads.atmosphere.copernicus.eu/api-how-to).
+In order to download the GFAS emissions data, credentials for the Copernicus
+Atmospheric Data Store (ADS) API are required. Instructions for registering for
+the ADS API and setting up the credentials are provided at 
+[ADS Docs](https://ads-beta.atmosphere.copernicus.eu/how-to-api).
 
-After creating an account and obtaining the credentials,
-you must also accept the general
-[license conditions for the data](https://ads.atmosphere.copernicus.eu/cdsapp/#!/terms/licence-to-use-copernicus-products)
-in order to download the data.
-You can check whether the license terms have been accepted by visiting the
-[GFAS Dataset](https://ads.atmosphere.copernicus.eu/cdsapp#!/dataset/cams-global-fire-emissions-gfas?tab=form)
-while logged in.
-The "Terms of Use" section at the bottom of the page shows the license
-and whether it has been accepted
+Step-by-step:
+- Register for an [ECMWF](https://www.ecmwf.int/) account
+- While logged in to ECMWF, register your account with [ADS](https://ads-beta.atmosphere.copernicus.eu/)
+- Accept the ADS terms and conditions
+- Accept the License to use Copernicus products, by visiting the Download tab of the dataset you wish to use and scrolling to the Terms of use section: https://ads-beta.atmosphere.copernicus.eu/datasets/cams-global-fire-emissions-gfas?tab=download
 
 Note: the ADS API is different from the CDS (Climate Data Store) API
 even though they are both parts of the Copernicus program

--- a/src/openmethane_prior/layers/omGFASEmis.py
+++ b/src/openmethane_prior/layers/omGFASEmis.py
@@ -36,6 +36,7 @@ import numpy as np
 import xarray as xr
 from shapely import geometry
 
+from openmethane_prior.inputs import initialise_output
 from openmethane_prior.config import PriorConfig, load_config_from_env
 from openmethane_prior.outputs import sum_layers, write_layer
 from openmethane_prior.utils import (
@@ -51,6 +52,10 @@ def download_GFAS(
 ):
     """Download GFAS methane between two dates startDate and endDate, returns nothing"""
     dateString = start_date.strftime("%Y-%m-%d") + "/" + end_date.strftime("%Y-%m-%d")
+
+    downloadPath = pathlib.Path(file_name);
+    downloadPath.parent.mkdir(parents=True, exist_ok=True)
+
     c = cdsapi.Client()
 
     c.retrieve(
@@ -84,7 +89,8 @@ def processEmissions(config: PriorConfig, startDate, endDate, forceUpdate: bool 
     gfas_file = download_GFAS(
         startDate, endDate, file_name=config.as_intermediate_file("gfas-download.nc")
     )
-    ncin = nc.Dataset(gfas_file, "r", format="NETCDF3")
+    ncin = nc.Dataset(gfas_file, "r", format="NETCDF4")
+
     latGfas = np.around(np.float64(ncin.variables["latitude"][:]), 3)
     latGfas = latGfas[::-1]  # they're originally north-south, we want them south north
     lonGfas = np.around(np.float64(ncin.variables["longitude"][:]), 3)
@@ -94,7 +100,8 @@ def processEmissions(config: PriorConfig, startDate, endDate, forceUpdate: bool 
     lonGfas_edge[0:-1] = lonGfas - dlonGfas / 2.0
     lonGfas_edge[-1] = lonGfas[-1] + dlonGfas / 2.0
     lonGfas_edge = np.around(lonGfas_edge, 2)
-    gfasTimes = nc.num2date(ncin.variables["time"][:], ncin.variables["time"].getncattr("units"))
+
+    gfasTimes = nc.num2date(ncin.variables["valid_time"][:], ncin.variables["valid_time"].getncattr("units"))
 
     latGfas_edge = np.zeros(len(latGfas) + 1)
     latGfas_edge[0:-1] = latGfas + dlatGfas / 2.0
@@ -210,7 +217,7 @@ def processEmissions(config: PriorConfig, startDate, endDate, forceUpdate: bool 
     cmaqAreas = np.ones(LAT.shape) * cmaqArea  # all grid cells equal area
 
     for i in range(gfasTimes.size):
-        dates.append(startDate + datetime.timedelta(days=i))
+        dates.append(gfasTimes[i])
         subset = ncin["ch4fire"][i, ...]
         subset = subset[::-1, :]  # they're listed north-south, we want them south north
         resultNd.append(
@@ -247,5 +254,6 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     config = load_config_from_env()
+    initialise_output(config)
     processEmissions(config, args.start_date, args.end_date)
     sum_layers(config.output_domain_file)

--- a/src/openmethane_prior/layers/omGFASEmis.py
+++ b/src/openmethane_prior/layers/omGFASEmis.py
@@ -101,8 +101,10 @@ def processEmissions(config: PriorConfig, startDate, endDate, forceUpdate: bool 
     lonGfas_edge[-1] = lonGfas[-1] + dlonGfas / 2.0
     lonGfas_edge = np.around(lonGfas_edge, 2)
 
-    gfasTimes = nc.num2date(ncin.variables["valid_time"][:], ncin.variables["valid_time"].getncattr("units"))
-
+    gfasTimesRaw = nc.num2date(ncin.variables["valid_time"][:], ncin.variables["valid_time"].getncattr("units"))
+    # dates are labelled at midnight at end of chosen day (hence looks like next day), subtract one day to fix
+    oneDay = datetime.timedelta(days=1)
+    gfasTimes = [t -oneDay for t in gfasTimesRaw]
     latGfas_edge = np.zeros(len(latGfas) + 1)
     latGfas_edge[0:-1] = latGfas + dlatGfas / 2.0
     latGfas_edge[-1] = latGfas[-1] - dlatGfas / 2.0
@@ -216,7 +218,7 @@ def processEmissions(config: PriorConfig, startDate, endDate, forceUpdate: bool 
     dates = []
     cmaqAreas = np.ones(LAT.shape) * cmaqArea  # all grid cells equal area
 
-    for i in range(gfasTimes.size):
+    for i in range(len(gfasTimes)):
         dates.append(gfasTimes[i])
         subset = ncin["ch4fire"][i, ...]
         subset = subset[::-1, :]  # they're listed north-south, we want them south north

--- a/tests/integration/test_layers/test_gfas_emis.py
+++ b/tests/integration/test_layers/test_gfas_emis.py
@@ -4,20 +4,24 @@ import netCDF4 as nc
 import numpy as np
 import pytest
 
+from openmethane_prior.inputs import initialise_output
 from openmethane_prior.layers.omGFASEmis import processEmissions
 from openmethane_prior.utils import area_of_rectangle_m2
 
 
-@pytest.mark.skip(reason="Needs an example GFAS file")
-def test_gfas_emis(config):  # test totals for GFAS emissions between original and remapped
+# @pytest.mark.skip(reason="Needs an example GFAS file")
+def test_gfas_emis(config, input_files, input_domain):  # test totals for GFAS emissions between original and remapped
+    # TODO: Check the output correctly
+    initialise_output(config)
+
     remapped = processEmissions(
         config=config,
         startDate=datetime.date(2022, 7, 2),
         endDate=datetime.date(2022, 7, 2),
         forceUpdate=True,
     )
-    GFASfile = "download.nc"
-    ncin = nc.Dataset(GFASfile, "r", format="NETCDF3")
+    GFASfile = config.as_intermediate_file("gfas-download.nc")
+    ncin = nc.Dataset(GFASfile, "r", format="NETCDF4")
     latGfas = np.around(np.float64(ncin.variables["latitude"][:]), 3)
     lonGfas = np.around(np.float64(ncin.variables["longitude"][:]), 3)
     dlatGfas = latGfas[0] - latGfas[1]


### PR DESCRIPTION
## Description

Resolves #19 .

The Copernicus CDS and ADS systems are being migrated to a new architecture, and all clients must update to use the new "ADS beta" and "CDS beta" before the legacy system is decomissioned on 26/09/2024.

This change in the code is accompanied by a new account being created, and the `CDSAPI_ADS_KEY` Organisation secret in Github Actions being replaced with new credentials.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests passing
- [x] Documentation added (where applicable)
<!--- Below to be added back once we have a changelog --> 
<!--- - [ ] Changelog item added to `changelog/`) -->

## Notes
