### PR TITLE
Replace ads-beta URLs with prod ads URLs

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -85,7 +85,7 @@ jobs:
           python -m pytest -r a -v tests/integration/test_domain_json.py
         env:
           CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
-          CDSAPI_URL: https://ads-beta.atmosphere.copernicus.eu/api
+          CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api
 
   # Tag the latest image if running on the main branch
   # TODO: Handle tagged builds

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
          make test
         env:
           CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
-          CDSAPI_URL: https://ads-beta.atmosphere.copernicus.eu/api
+          CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api
 
   imports-without-extras:
     strategy:

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Copy the `.env.example` file to `.env` and customise the paths as you need.
 In order to download the GFAS emissions data, credentials for the Copernicus
 Atmospheric Data Store (ADS) API are required. Instructions for registering for
 the ADS API and setting up the credentials are provided at 
-[ADS Docs](https://ads-beta.atmosphere.copernicus.eu/how-to-api).
+[ADS Docs](https://ads.atmosphere.copernicus.eu/how-to-api).
 
 Step-by-step:
 - Register for an [ECMWF](https://www.ecmwf.int/) account
-- While logged in to ECMWF, register your account with [ADS](https://ads-beta.atmosphere.copernicus.eu/)
+- While logged in to ECMWF, register your account with [ADS](https://ads.atmosphere.copernicus.eu/)
 - Accept the ADS terms and conditions
-- Accept the License to use Copernicus products, by visiting the Download tab of the dataset you wish to use and scrolling to the Terms of use section: https://ads-beta.atmosphere.copernicus.eu/datasets/cams-global-fire-emissions-gfas?tab=download
+- Accept the License to use Copernicus products, by visiting the Download tab of the dataset you wish to use and scrolling to the Terms of use section: https://ads.atmosphere.copernicus.eu/datasets/cams-global-fire-emissions-gfas?tab=download
 
 Note: the ADS API is different from the CDS (Climate Data Store) API
 even though they are both parts of the Copernicus program


### PR DESCRIPTION
## Description

The legacy ADS system has been decommissioned, and ads URLs now point to their new production system, previously known as ads-beta. The ads-beta URLs will be redirected to the production infrastructure for the next month, but we can now access the production ADS system through the previous URL.

https://forum.ecmwf.int/t/goodbye-legacy-ads-hello-new-atmosphere-data-store-ads/6381

> url: https://ads-beta.atmosphere.copernicus.eu/api → url: https://ads.atmosphere.copernicus.eu/api

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests passing
- [x] Documentation added (where applicable)
<!--- Below to be added back once we have a changelog --> 
<!--- - [ ] Changelog item added to `changelog/`) -->

## Notes
