### PR TITLE
Output terminology and filename

### DIFF
--- a/changelog/75.breaking.md
+++ b/changelog/75.breaking.md
@@ -1,0 +1,2 @@
+Default output filename has been changed from `out-om-domain-info.nc` to
+`prior_emissions.nc`

--- a/scripts/omPrior.py
+++ b/scripts/omPrior.py
@@ -75,7 +75,7 @@ def run_prior(
     omGFASEmis.processEmissions(config, start_date, end_date)
     omWetlandEmis.processEmissions(config, start_date, end_date)
 
-    sum_sectors(config.output_domain_file)
+    sum_sectors(config.output_file)
     verify_emis(config)
 
 

--- a/src/openmethane_prior/config.py
+++ b/src/openmethane_prior/config.py
@@ -68,11 +68,14 @@ class PriorConfig:
     input_domain: PublishedInputDomain | str
     """Input domain specification
 
-    If provided, use a published domain as the input domain.
-    Otherwise, a file named `output_domain` is used as the input domain.
+    If provided, use a published domain as the input domain. Otherwise, a file
+    specified in the `DOMAIN` env variable is used as the input domain.
     """
-    output_domain: str
-    """Name of the output domain file"""
+
+    output_filename: str
+    """Filename to write the prior output to as a NetCDFv4 file in
+    `output_path`"""
+
     layer_inputs: LayerInputs
 
     def as_input_file(self, name: str | pathlib.Path) -> pathlib.Path:
@@ -124,9 +127,9 @@ class PriorConfig:
             raise TypeError("Could not interpret the 'input_domain' field")
 
     @property
-    def output_domain_file(self):
+    def output_file(self):
         """Get the filename of the output domain"""
-        return self.as_output_file(self.output_domain)
+        return self.as_output_file(self.output_filename)
 
 
 def load_config_from_env(**overrides: typing.Any) -> PriorConfig:
@@ -151,7 +154,6 @@ def load_config_from_env(**overrides: typing.Any) -> PriorConfig:
         )
     else:
         # Default to using a user-specified file as the input domain
-        # TODO: Log?
         input_domain = env.str("DOMAIN")
 
     options = dict(
@@ -160,7 +162,7 @@ def load_config_from_env(**overrides: typing.Any) -> PriorConfig:
         output_path=env.path("OUTPUTS", "data/outputs"),
         intermediates_path=env.path("INTERMEDIATES", "data/processed"),
         input_domain=input_domain,
-        output_domain=env.str("OUTPUT_DOMAIN", "out-om-domain-info.nc"),
+        output_filename=env.str("OUTPUT_FILENAME", "prior_emissions.nc"),
         layer_inputs=LayerInputs(
             electricity_path=env.path("CH4_ELECTRICITY"),
             oil_gas_path=env.path("CH4_OILGAS"),

--- a/src/openmethane_prior/config.py
+++ b/src/openmethane_prior/config.py
@@ -55,6 +55,14 @@ class PublishedInputDomain:
             f"prior_domain_{self.name}_{self.version}.d{self.domain_index:02}.nc"
         )
 
+class PriorConfigOptions(typing.TypedDict, total=False):
+    remote: str
+    input_path: pathlib.Path | str
+    output_path: pathlib.Path | str
+    intermediates_path: pathlib.Path | str
+    input_domain: PublishedInputDomain | str
+    output_filename: str
+    layer_inputs: LayerInputs
 
 @attrs.frozen
 class PriorConfig:
@@ -132,7 +140,7 @@ class PriorConfig:
         return self.as_output_file(self.output_filename)
 
 
-def load_config_from_env(**overrides: typing.Any) -> PriorConfig:
+def load_config_from_env(**overrides: PriorConfigOptions) -> PriorConfig:
     """
     Load the configuration from the environment variables
 
@@ -156,8 +164,8 @@ def load_config_from_env(**overrides: typing.Any) -> PriorConfig:
         # Default to using a user-specified file as the input domain
         input_domain = env.str("DOMAIN")
 
-    options = dict(
-        remote=env("PRIOR_REMOTE"),
+    options: PriorConfigOptions = dict(
+        remote=env.str("PRIOR_REMOTE"),
         input_path=env.path("INPUTS", "data/inputs"),
         output_path=env.path("OUTPUTS", "data/outputs"),
         intermediates_path=env.path("INTERMEDIATES", "data/processed"),

--- a/src/openmethane_prior/config.py
+++ b/src/openmethane_prior/config.py
@@ -170,7 +170,7 @@ def load_config_from_env(**overrides: PriorConfigOptions) -> PriorConfig:
         output_path=env.path("OUTPUTS", "data/outputs"),
         intermediates_path=env.path("INTERMEDIATES", "data/processed"),
         input_domain=input_domain,
-        output_filename=env.str("OUTPUT_FILENAME", "prior_emissions.nc"),
+        output_filename=env.str("OUTPUT_FILENAME", "prior-emissions.nc"),
         layer_inputs=LayerInputs(
             electricity_path=env.path("CH4_ELECTRICITY"),
             oil_gas_path=env.path("CH4_OILGAS"),

--- a/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
+++ b/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
@@ -218,7 +218,7 @@ def processEmissions(config: PriorConfig):  # noqa: PLR0912, PLR0915
     print("Writing sectoral methane layers output file")
     for sector in sectorsUsed:
         write_sector(
-            output_path=config.output_domain_file,
+            output_path=config.output_file,
             sector_name=sector.lower(),
             sector_data=convert_to_timescale(methane[sector], cell_area=domain_grid.cell_area),
             sector_standard_name=sectorEmissionStandardNames[sector],
@@ -228,7 +228,7 @@ def processEmissions(config: PriorConfig):  # noqa: PLR0912, PLR0915
     # convert the livestock data from per year to per second and write
     livestock_ch4_s = livestockCH4 / SECS_PER_YEAR
     write_sector(
-        output_path=config.output_domain_file,
+        output_path=config.output_file,
         sector_name="livestock",
         sector_data=livestock_ch4_s,
         sector_standard_name="domesticated_livestock",
@@ -238,4 +238,4 @@ def processEmissions(config: PriorConfig):  # noqa: PLR0912, PLR0915
 if __name__ == "__main__":
     config = load_config_from_env()
     processEmissions(config)
-    sum_sectors(config.output_domain_file)
+    sum_sectors(config.output_file)

--- a/src/openmethane_prior/layers/omElectricityEmis.py
+++ b/src/openmethane_prior/layers/omElectricityEmis.py
@@ -56,7 +56,7 @@ def processEmissions(config: PriorConfig):
             methane[cell_coords[1], cell_coords[0]] += (facility["capacity"] / totalCapacity) * electricityEmis
 
     write_sector(
-        output_path=config.output_domain_file,
+        output_path=config.output_file,
         sector_name="electricity",
         sector_data=convert_to_timescale(methane, domain_grid.cell_area),
         sector_standard_name="energy_production_and_distribution",
@@ -66,4 +66,4 @@ def processEmissions(config: PriorConfig):
 if __name__ == "__main__":
     config = load_config_from_env()
     processEmissions(config)
-    sum_sectors(config.output_domain_file)
+    sum_sectors(config.output_file)

--- a/src/openmethane_prior/layers/omFugitiveEmis.py
+++ b/src/openmethane_prior/layers/omFugitiveEmis.py
@@ -78,7 +78,7 @@ def processEmissions(config: PriorConfig, startDate, endDate):
             methane[cell_coords[1], cell_coords[0]] += facility["emissions_quantity"]
 
     write_sector(
-        output_path=config.output_domain_file,
+        output_path=config.output_file,
         sector_name="fugitive",
         sector_data=convert_to_timescale(methane, domain_grid.cell_area),
         sector_standard_name="extraction_production_and_transport_of_fuel",
@@ -103,4 +103,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     processEmissions(config, args.start_date, args.end_date)
-    sum_sectors(config.output_domain_file)
+    sum_sectors(config.output_file)

--- a/src/openmethane_prior/layers/omGFASEmis.py
+++ b/src/openmethane_prior/layers/omGFASEmis.py
@@ -237,7 +237,7 @@ def processEmissions(config: PriorConfig, startDate, endDate, forceUpdate: bool 
         },
     )
     write_sector(
-        output_path=config.output_domain_file,
+        output_path=config.output_file,
         sector_name="fire",
         sector_data=resultXr,
         sector_standard_name="fires",
@@ -263,4 +263,4 @@ if __name__ == "__main__":
     config = load_config_from_env()
     initialise_output(config, args.start_date, args.end_date)
     processEmissions(config, args.start_date, args.end_date)
-    sum_sectors(config.output_domain_file)
+    sum_sectors(config.output_file)

--- a/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
+++ b/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
@@ -107,7 +107,7 @@ def processEmissions(config: PriorConfig):
 
     for sector in sectorsUsed:
         write_sector(
-            output_path=config.output_domain_file,
+            output_path=config.output_file,
             sector_name=sector.lower(),
             sector_data=convert_to_timescale(methane[sector], domain_grid.cell_area),
             sector_standard_name=sectorEmissionStandardNames[sector],
@@ -117,4 +117,4 @@ def processEmissions(config: PriorConfig):
 if __name__ == "__main__":
     config = load_config_from_env()
     processEmissions(config)
-    sum_sectors(config.output_domain_file)
+    sum_sectors(config.output_file)

--- a/src/openmethane_prior/layers/omTermiteEmis.py
+++ b/src/openmethane_prior/layers/omTermiteEmis.py
@@ -185,7 +185,7 @@ def processEmissions(  # noqa: PLR0915
     ncin.close()
 
     write_sector(
-        output_path=config.output_domain_file,
+        output_path=config.output_file,
         sector_name="termite",
         sector_data=resultNd,
         sector_standard_name="termites",
@@ -196,4 +196,4 @@ def processEmissions(  # noqa: PLR0915
 if __name__ == "__main__":
     config = load_config_from_env()
     processEmissions(config)
-    sum_sectors(config.output_domain_file)
+    sum_sectors(config.output_file)

--- a/src/openmethane_prior/layers/omWetlandEmis.py
+++ b/src/openmethane_prior/layers/omWetlandEmis.py
@@ -234,7 +234,7 @@ def processEmissions(
         },
     )
     write_sector(
-        output_path=config.output_domain_file,
+        output_path=config.output_file,
         sector_name="wetlands",
         sector_data=resultXr,
         sector_standard_name="wetland_biological_processes",
@@ -259,4 +259,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
     config = load_config_from_env()
     processEmissions(config, args.start_date, args.end_date)
-    sum_sectors(config.output_domain_file)
+    sum_sectors(config.output_file)

--- a/src/openmethane_prior/outputs.py
+++ b/src/openmethane_prior/outputs.py
@@ -23,7 +23,7 @@ import numpy as np
 import numpy.typing as npt
 import xarray as xr
 
-from openmethane_prior.config import PriorConfig
+from openmethane_prior.config import PriorConfig, PublishedInputDomain
 from openmethane_prior.utils import SECS_PER_YEAR, get_version, get_timestamped_command, time_bounds, \
     bounds_from_cell_edges
 
@@ -143,10 +143,13 @@ def create_output_dataset(
             # "vertical": (("vertical"), [0], {}),
         },
         attrs={
+            # data attributes
             "DX": domain_ds.DX,
             "DY": domain_ds.DY,
             "XCELL": domain_ds.XCELL,
             "YCELL": domain_ds.YCELL,
+
+            # meta attributes
             "title": "Open Methane prior emissions estimate",
             "comment": "Gridded prior emissions estimate for methane across Australia",
             "history": get_timestamped_command(),
@@ -160,6 +163,15 @@ def create_output_dataset(
     time_encoding = f"days since {period_start.strftime('%Y-%m-%d')}"
     prior_ds.time.encoding["units"] = time_encoding
     prior_ds.time_bounds.encoding["units"] = time_encoding
+
+    # if the domain is well specified, include details in attributes
+    if type(config.input_domain) == PublishedInputDomain:
+        prior_ds.attrs["domain_name"] = config.input_domain.name
+        prior_ds.attrs["domain_version"] = config.input_domain.version
+        # this seems useful, but with the current config is hard to derive
+        # as only the omDownloadInputs script assembles this URL
+        # prior_ds.attrs["domain_url"] = config.input_domain.url_fragment()
+
 
     return prior_ds
 

--- a/src/openmethane_prior/outputs.py
+++ b/src/openmethane_prior/outputs.py
@@ -179,10 +179,10 @@ def initialise_output(
     config
         Configuration object
     """
-    config.output_domain_file.parent.mkdir(parents=True, exist_ok=True)
+    config.output_file.parent.mkdir(parents=True, exist_ok=True)
 
     output_ds = create_output_dataset(config, start_date, end_date)
-    output_ds.to_netcdf(config.output_domain_file)
+    output_ds.to_netcdf(config.output_file)
 
 
 def write_sector(

--- a/src/openmethane_prior/verification.py
+++ b/src/openmethane_prior/verification.py
@@ -55,7 +55,7 @@ def verify_emis(config: PriorConfig, atol: float = MAX_ABS_DIFF):
         )
 
     # Check each layer in the output sums up to the input
-    with xr.open_dataset(config.output_domain_file) as dss:
+    with xr.open_dataset(config.output_file) as dss:
         ds = dss.load()
 
     modelAreaM2 = config.domain_grid().cell_area

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,9 +232,9 @@ def output_domain(
         False,
     )
 
-    yield xr.load_dataset(config.output_domain_file)
+    yield xr.load_dataset(config.output_file)
 
-    os.remove(config.output_domain_file)
+    os.remove(config.output_file)
 
     # Manually clean up any leftover files
     for filepath in input_files:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pathlib
 import shutil
 from datetime import datetime
 from pathlib import Path
+from typing import Generator
 
 import attrs
 import dotenv
@@ -123,8 +124,10 @@ def fetch_input_files(root_dir) -> list[pathlib.Path]:
 
 
 def copy_input_files(
-    cache_path: pathlib.Path, input_path: str | pathlib.Path, cached_fragments: list[pathlib.Path]
-):
+    cache_path: pathlib.Path,
+    input_path: pathlib.Path,
+    cached_fragments: list[pathlib.Path],
+) -> Generator[list[pathlib.Path], None, None]:
     """
     Copy input files from the cache into the input directory
 
@@ -158,7 +161,9 @@ def copy_input_files(
 
 
 @pytest.fixture()
-def input_files(root_dir, fetch_input_files, fetch_published_domain, config) -> list[pathlib.Path]:
+def input_files(
+    root_dir, fetch_input_files, fetch_published_domain, config,
+) -> Generator[list[pathlib.Path], None, None]:
     """
     Ensure that the required input files are in the input directory.
 
@@ -172,7 +177,7 @@ def input_files(root_dir, fetch_input_files, fetch_published_domain, config) -> 
 
 
 @pytest.fixture()
-def input_domain(config, root_dir, input_files) -> xr.Dataset:
+def input_domain(config, root_dir, input_files) -> Generator[xr.Dataset, None, None]:
     """
     Get an input domain
 
@@ -186,14 +191,14 @@ def input_domain(config, root_dir, input_files) -> xr.Dataset:
 
 
 @pytest.fixture(scope="session")
-def output_domain(
+def prior_emissions_ds(
     root_dir,
     fetch_input_files,
     fetch_published_domain,
     start_date,
     end_date,
     tmp_path_factory,
-) -> xr.Dataset:
+) -> Generator[xr.Dataset, None, None]:
     """
     Run the output domain
 

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -5,11 +5,11 @@ import pytest
 from openmethane_prior.outputs import initialise_output, create_output_dataset, expand_sector_dims
 
 def test_initialise_output(config, input_files, start_date, end_date):
-    assert not config.output_domain_file.exists()
+    assert not config.output_file.exists()
 
     initialise_output(config, start_date, end_date)
 
-    assert config.output_domain_file.exists()
+    assert config.output_file.exists()
 
     # Idempotent
     initialise_output(config, start_date, end_date)
@@ -18,7 +18,7 @@ def test_initialise_output(config, input_files, start_date, end_date):
 def test_create_output_dataset(config, input_files, start_date, end_date):
     domain_ds = config.domain_dataset()
 
-    assert not config.output_domain_file.exists()
+    assert not config.output_file.exists()
 
     output_ds = create_output_dataset(config, start_date, end_date)
 

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -39,6 +39,9 @@ def test_create_output_dataset(config, input_files, start_date, end_date):
     assert isinstance(output_ds.attrs["history"], str)
     assert isinstance(output_ds.attrs["openmethane_prior_version"], str)
 
+    assert output_ds.attrs["domain_name"] == "aust10km"
+    assert output_ds.attrs["domain_version"] == "v1.0.0"
+
     # projection
     assert output_ds["lambert_conformal"].attrs["grid_mapping_name"] == "lambert_conformal_conic"
     assert output_ds["lambert_conformal"].attrs["standard_parallel"] == (domain_ds.attrs["TRUELAT1"], domain_ds.attrs["TRUELAT2"])


### PR DESCRIPTION
## Description

Throughout the prior codebase the term "output domain" is used to describe the output file, including the default output filename `out-om-domain-info.nc`. Using the term "domain" in this context is a relic of how the prior was built, and doesn't help describe what's actually being produced.

This PR simplifies language around the output, removing the word "domain", so we're left with:
- `OUTPUT_FILENAME` instead of `OUTPUT_DOMAIN`
- `output_file` instead of `output_domain_file`
- `prior_emissions_ds` test fixture instead of `output_domain`

The only functional change is to the default output filename, which previously was `out-om-domain-info.nc`, has been updated to `prior-emissions.nc`. This is more descriptive and aligns with our other downstream outputs such as `posterior-emissions.nc`.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes

Previously, this PR aimed to change the default output filename to a pattern including the domain name and version, like `prior_emissions.{domain_name}.{domain_version}.nc`. However, we agreed after discussion that a static output name will be simpler for downstream consumers, and putting the domain details as attributes in the file makes them easier to work with.
