### PR TITLE
Grid cell name

### DIFF
--- a/changelog/83.improvement.md
+++ b/changelog/83.improvement.md
@@ -1,0 +1,1 @@
+Add "cell_name" to output file with a short unique name for each grid cell

--- a/src/openmethane_prior/cell_name.py
+++ b/src/openmethane_prior/cell_name.py
@@ -1,0 +1,51 @@
+
+alphabet = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+
+def encode_word_safe(v: int) -> str:
+    """
+    Encode an integer (like a grid coordinate) as a short string using
+    url-safe characters.
+    """
+    remaining = v
+    output = ''
+    i = 1
+    while i == 1 or remaining > 0:
+        digit = remaining % (len(alphabet) ** i)
+        if digit != 0:
+            remaining -= digit
+        remaining = remaining // (len(alphabet) ** i)
+        i += 1
+        output = f"{alphabet[digit]}{output}"
+    return output
+
+def decode_word_safe(v: str) -> int:
+    """
+    Decode a value encoded with encode_word_safe back to an integer.
+    """
+    output = 0
+    for place in range(len(v), 0, -1):
+        digit = v[place - 1]
+        value = alphabet.index(digit)
+        output += value * (len(alphabet) ** (len(v) - place))
+    return output
+
+def encode_grid_cell_name(grid_name: str, x: int, y: int, separator: str = '.') -> str:
+    """
+    Turn the three components that identify a grid cell (grid, x and y) into a
+    unique, URL-safe string.
+    """
+    return separator.join([grid_name, encode_word_safe(x), encode_word_safe(y)])
+
+def decode_grid_cell_name(grid_cell_name: str, separator: str = '.') -> dict:
+    """
+
+    :param grid_cell_name:
+    :param separator:
+    :return:
+    """
+    grid_name, enc_x, enc_y = grid_cell_name.split(separator)
+    return {
+        'grid': grid_name,
+        'x': decode_word_safe(enc_x),
+        'y': decode_word_safe(enc_y)
+    }

--- a/src/openmethane_prior/outputs.py
+++ b/src/openmethane_prior/outputs.py
@@ -181,6 +181,9 @@ def create_output_dataset(
     prior_ds.time.encoding["units"] = time_encoding
     prior_ds.time_bounds.encoding["units"] = time_encoding
 
+    # compress cell_names which take a lot of space
+    prior_ds.cell_name.encoding["zlib"] = True
+
     return prior_ds
 
 

--- a/src/openmethane_prior/outputs.py
+++ b/src/openmethane_prior/outputs.py
@@ -23,6 +23,7 @@ import numpy as np
 import numpy.typing as npt
 import xarray as xr
 
+from openmethane_prior.cell_name import encode_grid_cell_name
 from openmethane_prior.config import PriorConfig, PublishedInputDomain
 from openmethane_prior.utils import SECS_PER_YEAR, get_version, get_timestamped_command, time_bounds, \
     bounds_from_cell_edges
@@ -58,6 +59,14 @@ def create_output_dataset(
 
     # generate daily time steps
     time_steps = xr.date_range(start=period_start, end=period_end, freq="D", use_cftime=True, normalize=True)
+
+    # generate grid cell names
+    # TODO: generate and store these when creating the domain file
+    grid_cell_names = []
+    for y in range(domain_grid.shape[0]):
+        grid_cell_names.append([])
+        for x in range(domain_grid.shape[1]):
+            grid_cell_names[-1].append(encode_grid_cell_name(config.input_domain.slug, x, y, "."))
 
     # copy dimensions and attributes from the domain where the grid is defined
     prior_ds = xr.Dataset(
@@ -102,6 +111,9 @@ def create_output_dataset(
                 ("time", "time_period"),
                 time_bounds(time_steps),
             ),
+            "cell_name": (("y", "x"), grid_cell_names, {
+                "long_name": "unique grid cell name",
+            }),
 
             # data variables
             "land_mask": (

--- a/tests/integration/test_om_prior.py
+++ b/tests/integration/test_om_prior.py
@@ -67,7 +67,8 @@ def test_005_agriculture_emissions(config, root_dir, input_files):
 
 
 def test_009_prior_emissions_ds(prior_emissions_ds):
-    mean_values = {key: prior_emissions_ds[key].mean().item() for key in prior_emissions_ds.keys()}
+    numeric_keys = [key for key in prior_emissions_ds.keys() if np.issubdtype(prior_emissions_ds[key].dtype, np.number)]
+    mean_values = {key: prior_emissions_ds[key].mean().item() for key in numeric_keys}
 
     expected_values = {
         "lambert_conformal": 0.0,
@@ -75,7 +76,6 @@ def test_009_prior_emissions_ds(prior_emissions_ds):
         "lon": 133.302001953125,
         "x_bounds": 0.0,
         "y_bounds": 0.02444604212461516,
-        "time_bounds": 1656720000000000000,
         "land_mask": 0.39128163098043234,
         "ch4_sector_agriculture": 3.8221794892533713e-13,
         "ch4_sector_lulucf": 8.2839841777071689e-13,

--- a/tests/unit/test_cell_name.py
+++ b/tests/unit/test_cell_name.py
@@ -1,0 +1,46 @@
+
+from openmethane_prior.cell_name import decode_grid_cell_name, encode_grid_cell_name, encode_word_safe, decode_word_safe
+
+expected_names = {
+    "A.0.0": ["A", 0, 0],
+    "A.1.1": ["A", 1, 1],
+    "A.0.1": ["A", 0, 1],
+    "A.1.0": ["A", 1, 0],
+    "A.Y.Y": ["A", 30, 30],
+    "A.Z.Z": ["A", 31, 31], # last character in safe alphabet
+    "A.10.10": ["A", 32, 32], # first 2-digit encoding
+    "A.11.11": ["A", 33, 33],
+    "10.A8.33": ["10", 328, 99], # Melbourne in aust10km
+    "10.C4.47": ["10", 388, 135], # Sydney in aust10km
+}
+
+def test_encode_grid_cell_name():
+    for expected_cell_name in expected_names.keys():
+        grid_slug, x, y = expected_names[expected_cell_name]
+        assert encode_grid_cell_name(grid_slug, x, y) == expected_cell_name
+
+def test_encode_grid_cell_name_separator():
+    # default separator is "."
+    assert encode_grid_cell_name("A", 0, 0) == "A.0.0"
+
+    # other separators can be specified
+    assert encode_grid_cell_name("A", 0, 0, "-") == "A-0-0"
+    assert encode_grid_cell_name("A", 0, 0, "") == "A00"
+
+def test_decode_grid_cell_name():
+    for expected_cell_name in expected_names.keys():
+        grid_slug, x, y = expected_names[expected_cell_name]
+        assert decode_grid_cell_name(expected_cell_name) == { "grid": grid_slug, "x": x, "y": y }
+
+def test_decode_grid_cell_name_separator():
+    # default separator is "."
+    assert decode_grid_cell_name("A.0.0") == { "grid": "A", "x": 0, "y": 0 }
+
+    # other separators can be specified
+    assert decode_grid_cell_name("A-0-0", "-") == { "grid": "A", "x": 0, "y": 0 }
+    assert decode_grid_cell_name("A%0%0", "%") == { "grid": "A", "x": 0, "y": 0 }
+
+def test_encode_decode_round_trip():
+    for integer in range(0, 1000):
+        encoded = encode_word_safe(integer)
+        assert decode_word_safe(encoded) == integer

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -59,6 +59,12 @@ def test_create_output_dataset(config, input_files, start_date, end_date):
     assert output_ds["y"].attrs["bounds"] == "y_bounds"
     assert output_ds["y_bounds"].shape == (output_ds["y"].size, 2)
 
+    # grid cell names
+    assert str(output_ds["cell_name"][0, 0].data) == "10.0.0"
+    assert str(output_ds["cell_name"][31, 32].data) == "10.10.Z"
+    assert str(output_ds["cell_name"][99, 328].data) == "10.A8.33"
+    assert str(output_ds["cell_name"][135, 388].data) == "10.C4.47"
+
 
 def test_expand_sector_dims_errors():
     test_xr = xr.DataArray([1, 2, 3]) # 1-dimensional array


### PR DESCRIPTION
## Description

Resolves #9.

This PR adds a `cell_name` variable to the prior output, which contains a unique, short name for every cell based on the parent grid slug and the cell coordinates. The function has already been used to generate grid cell names for the front-end, this simply moves it into the back-end and pre-generates the names for later use.

This has the obvious utility that the naming scheme becomes embedded in the output from very early stages, and can be shared by all downstream consumers without re-implementing the encoding. The code in the front-end for generating these names can be removed and they can be read directly from the prior output into the web app database.

The downside is the additional storage this adds to the output file. Testing with and without the `cell_name` variable for a 3-day prior on the "aust10km" domain yields an increase from 21Mb to 31Mb, so roughly 10Mb or 50%. Although the relative increase is large, I don't see 10Mb posing a serious problem for us or downstream consumers.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
