### PR TITLE
Write output once

### DIFF
--- a/changelog/85.enhancement.md
+++ b/changelog/85.enhancement.md
@@ -1,0 +1,1 @@
+Output will only be written to disk at the end of processing

--- a/scripts/omPrior.py
+++ b/scripts/omPrior.py
@@ -31,7 +31,7 @@ from openmethane_prior.layers import (
     omTermiteEmis,
     omWetlandEmis,
 )
-from openmethane_prior.outputs import sum_sectors, initialise_output
+from openmethane_prior.outputs import add_ch4_total, create_output_dataset, write_output_dataset
 from openmethane_prior.raster import reproject_raster_inputs
 from openmethane_prior.verification import verify_emis
 
@@ -53,22 +53,24 @@ def run_prior(config: PriorConfig):
     check_input_files(config)
 
     # Initialise the output dataset based on the domain provided in config
-    initialise_output(config)
+    prior_ds = create_output_dataset(config)
 
     if not config.skip_reproject:
         reproject_raster_inputs(config)
 
-    omAgLulucfWasteEmis.processEmissions(config)
-    omIndustrialStationaryTransportEmis.processEmissions(config)
-    omElectricityEmis.processEmissions(config)
-    omFugitiveEmis.processEmissions(config)
+    omAgLulucfWasteEmis.processEmissions(config, prior_ds)
+    omIndustrialStationaryTransportEmis.processEmissions(config, prior_ds)
+    omElectricityEmis.processEmissions(config, prior_ds)
+    omFugitiveEmis.processEmissions(config, prior_ds)
 
-    omTermiteEmis.processEmissions(config)
-    omGFASEmis.processEmissions(config)
-    omWetlandEmis.processEmissions(config)
+    omTermiteEmis.processEmissions(config, prior_ds)
+    omGFASEmis.processEmissions(config, prior_ds)
+    omWetlandEmis.processEmissions(config, prior_ds)
 
-    sum_sectors(config.output_file)
-    verify_emis(config)
+    add_ch4_total(prior_ds)
+    verify_emis(config, prior_ds)
+
+    write_output_dataset(config, prior_ds)
 
 
 if __name__ == "__main__":

--- a/src/openmethane_prior/outputs.py
+++ b/src/openmethane_prior/outputs.py
@@ -176,6 +176,11 @@ def create_output_dataset(config: PriorConfig) -> xr.Dataset:
     # compress cell_names which take a lot of space
     prior_ds.cell_name.encoding["zlib"] = True
 
+    # disable _FillValue for variables that shouldn't have empty values
+    prior_ds.time_bounds.encoding["_FillValue"] = None
+    prior_ds.x_bounds.encoding["_FillValue"] = None
+    prior_ds.y_bounds.encoding["_FillValue"] = None
+
     return prior_ds
 
 

--- a/src/openmethane_prior/utils.py
+++ b/src/openmethane_prior/utils.py
@@ -38,29 +38,6 @@ T = typing.TypeVar("T", bound=ArrayLike | float)
 SECS_PER_YEAR = 365 * 24 * 60 * 60
 
 
-def date_time_range(start: datetime.date, end: datetime.date, delta: datetime.timedelta):
-    """Iterate over a range of dates between start and end.
-
-    Parameters
-    ----------
-    start
-        Start date (inclusive)
-    end
-        Start date (exclusive)
-    delta
-        Time delta to step over
-
-    Yields
-    ------
-        Dates between start and end (exclusive)
-
-    """
-    t = start
-    while t < end:
-        yield t
-        t += delta
-
-
 def save_zipped_pickle(obj, filename: str | pathlib.Path, protocol=-1):
     """Save a compressed pickle file."""
     pathlib.Path(filename).parent.mkdir(parents=True, exist_ok=True)

--- a/tests/integration/test_layers/test_gfas_emis.py
+++ b/tests/integration/test_layers/test_gfas_emis.py
@@ -2,7 +2,7 @@ import netCDF4 as nc
 import numpy as np
 import pytest
 
-from openmethane_prior.outputs import initialise_output
+from openmethane_prior.outputs import create_output_dataset
 from openmethane_prior.layers.omGFASEmis import processEmissions
 from openmethane_prior.utils import area_of_rectangle_m2
 
@@ -10,9 +10,9 @@ from openmethane_prior.utils import area_of_rectangle_m2
 @pytest.mark.skip(reason="Makes no assertions")
 def test_gfas_emis(config, input_files, input_domain):  # test totals for GFAS emissions between original and remapped
     # TODO: Check the output correctly
-    initialise_output(config)
+    prior_ds = create_output_dataset(config)
 
-    remapped = processEmissions(config=config, forceUpdate=True)
+    remapped = processEmissions(config=config, prior_ds=prior_ds, forceUpdate=True)
 
     GFASfile = config.as_intermediate_file("gfas-download.nc")
     ncin = nc.Dataset(GFASfile, "r", format="NETCDF4")

--- a/tests/integration/test_layers/test_termite_emis.py
+++ b/tests/integration/test_layers/test_termite_emis.py
@@ -2,16 +2,16 @@ import netCDF4 as nc
 import numpy as np
 import pytest
 
-from openmethane_prior.outputs import initialise_output
+from openmethane_prior.outputs import create_output_dataset
 from openmethane_prior.layers.omTermiteEmis import processEmissions
 from openmethane_prior.utils import area_of_rectangle_m2
 
 @pytest.mark.skip(reason="Makes no assertions")
 def test_termite_emis(config, input_files, input_domain):
     # TODO: Check the output correctly
-    initialise_output(config)
+    prior_ds = create_output_dataset(config)
 
-    remapped = processEmissions(config=config, forceUpdate=True)
+    remapped = processEmissions(config=config, prior_ds=prior_ds, forceUpdate=True)
     ncin = nc.Dataset(config.as_input_file(config.layer_inputs.termite_path), "r")
     latTerm = np.around(np.float64(ncin.variables["lat"][:]), 3)
     latTerm = latTerm[-1::-1]  # reversing order, we need south first

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -2,17 +2,16 @@ import numpy as np
 import xarray as xr
 import pytest
 
-from openmethane_prior.outputs import initialise_output, create_output_dataset, expand_sector_dims
+from openmethane_prior.outputs import create_output_dataset, expand_sector_dims, write_output_dataset
 
-def test_initialise_output(config, input_files):
+def test_write_output_dataset(config, input_files):
+    output_ds = create_output_dataset(config)
+
     assert not config.output_file.exists()
 
-    initialise_output(config)
+    write_output_dataset(config, output_ds)
 
     assert config.output_file.exists()
-
-    # Idempotent
-    initialise_output(config)
 
 
 def test_create_output_dataset(config, input_files):


### PR DESCRIPTION
## Description

Instead of writing output to disk at each stage of the prior (initialisation, each layer, summing the total), this change re-architects the process to build a Dataset from initialisation through layer processing, eventually writing to disk at the end of the process.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
