### PR TITLE
Improve Grid performance

### DIFF
--- a/changelog/86.improvement.1.md
+++ b/changelog/86.improvement.1.md
@@ -1,0 +1,1 @@
+Fix Grid performance by removing `@property` usage

--- a/changelog/86.improvement.2.md
+++ b/changelog/86.improvement.2.md
@@ -1,0 +1,1 @@
+Add `Grid.lonlat_to_cell_index` method which works efficiently on lists

--- a/src/openmethane_prior/grid/grid.py
+++ b/src/openmethane_prior/grid/grid.py
@@ -120,34 +120,6 @@ class Grid:
             (coord_y >= 0) & (coord_y < self.dimensions[1])
         )
 
-    def find_cell(
-        self,
-        xy: tuple[float, float] | None = None,
-        lonlat: tuple[float, float] | None = None,
-    ) -> tuple[int, int] | None:
-        """
-        Return the grid cell coordinates for the cell which contains the
-        point provided in xy or lonlat arguments.
-        :param xy: Search point in grid projection coordinates.
-        :param lonlat: Search point in longitude / latitude coordinates.
-        :return: Grid cell coordinates or None if coords are not in the grid
-        """
-        if xy is None and lonlat is None:
-            raise ValueError("find_cell: xy or lonlat must be provided")
-        if xy is not None and lonlat is not None:
-            raise ValueError("find_cell: provide only one of xy or lonlat")
-
-        search_x, search_y = xy if xy is not None else self.lonlat_to_xy(*lonlat)
-
-        grid_coords = (
-            int((search_x - self.llc_xy[0]) // self.cell_size[0]),
-            int((search_y - self.llc_xy[1]) // self.cell_size[1])
-        )
-
-        if self.valid_cell_coords(grid_coords[0], grid_coords[1]):
-            return grid_coords
-        return None
-
     def lonlat_to_cell_index(self, lon: Any, lat: Any) -> tuple[Any, Any, Any]:
         """
         Find the grid cell indices for the cells containing each provided

--- a/src/openmethane_prior/grid/grid.py
+++ b/src/openmethane_prior/grid/grid.py
@@ -111,13 +111,13 @@ class Grid:
         """
         return self.llc_xy[1] + np.arange(self.dimensions[1] + 1) * self.cell_size[1]
 
-    def valid_cell_coords(self, coords: tuple[int, int]) -> bool:
+    def valid_cell_coords(self, coord_x: int, coord_y: int) -> bool:
         """
         Return true if the grid cell coords refer to a valid cell in the grid.
         """
         return (
-            coords[0] >= 0 and coords[0] < self.dimensions[0] and
-            coords[1] >= 0 and coords[1] < self.dimensions[1]
+            (coord_x >= 0) & (coord_x < self.dimensions[0]) &
+            (coord_y >= 0) & (coord_y < self.dimensions[1])
         )
 
     def find_cell(
@@ -143,7 +143,10 @@ class Grid:
             int((search_x - self.llc_xy[0]) // self.cell_size[0]),
             int((search_y - self.llc_xy[1]) // self.cell_size[1])
         )
-        return grid_coords if self.valid_cell_coords(grid_coords) else None
+
+        if self.valid_cell_coords(grid_coords[0], grid_coords[1]):
+            return grid_coords
+        return None
 
     def lonlat_to_cell_index(self, lon: Any, lat: Any) -> tuple[Any, Any, Any]:
         """
@@ -158,7 +161,6 @@ class Grid:
         cell_index_y = np.floor((y - self.llc_xy[1]) / self.cell_size[1]).astype('int')
 
         # determine which coords are within the grid
-        mask = ((0 <= cell_index_x) & (cell_index_x < self.dimensions[0]) &
-                (0 <= cell_index_y) & (cell_index_y < self.dimensions[1]))
+        mask = self.valid_cell_coords(cell_index_x, cell_index_y)
 
         return cell_index_x, cell_index_y, mask

--- a/src/openmethane_prior/grid/grid.py
+++ b/src/openmethane_prior/grid/grid.py
@@ -144,3 +144,21 @@ class Grid:
             int((search_y - self.llc_xy[1]) // self.cell_size[1])
         )
         return grid_coords if self.valid_cell_coords(grid_coords) else None
+
+    def lonlat_to_cell_index(self, lon: Any, lat: Any) -> tuple[Any, Any, Any]:
+        """
+        Find the grid cell indices for the cells containing each provided
+        lon/lat coordinate. Return tuple also includes a binary mask in the
+        third position for whether coords are valid and inside the grid extent.
+        """
+        x, y = self.lonlat_to_xy(lon=lon, lat=lat)
+
+        # calculate indices assuming regular grid
+        cell_index_x = np.floor((x - self.llc_xy[0]) / self.cell_size[0]).astype('int')
+        cell_index_y = np.floor((y - self.llc_xy[1]) / self.cell_size[1]).astype('int')
+
+        # determine which coords are within the grid
+        mask = ((0 <= cell_index_x) & (cell_index_x < self.dimensions[0]) &
+                (0 <= cell_index_y) & (cell_index_y < self.dimensions[1]))
+
+        return cell_index_x, cell_index_y, mask

--- a/src/openmethane_prior/layers/omElectricityEmis.py
+++ b/src/openmethane_prior/layers/omElectricityEmis.py
@@ -55,7 +55,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     methane = np.zeros(domain_grid.shape)
 
     for facility in electricityFacilities:
-        cell_coords = domain_grid.find_cell(lonlat=(facility["lng"], facility["lat"]))
+        cell_coords = domain_grid.lonlat_to_cell_index(facility["lng"], facility["lat"])
 
         if cell_coords is not None:
             methane[cell_coords[1], cell_coords[0]] += (facility["capacity"] / totalCapacity) * electricityEmis

--- a/src/openmethane_prior/layers/omFugitiveEmis.py
+++ b/src/openmethane_prior/layers/omFugitiveEmis.py
@@ -69,7 +69,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     methane = np.zeros(domain_grid.shape)
 
     for _, facility in fugitiveYear.iterrows():
-        cell_coords = domain_grid.find_cell(lonlat=(facility["lon"], facility["lat"]))
+        cell_coords = domain_grid.lonlat_to_cell_index(facility["lon"], facility["lat"])
 
         if cell_coords is not None:
             methane[cell_coords[1], cell_coords[0]] += facility["emissions_quantity"]

--- a/tests/unit/test_grid/test_domain_grid.py
+++ b/tests/unit/test_grid/test_domain_grid.py
@@ -107,18 +107,18 @@ def test_grid_projection_coordinates(input_domain):
 def test_grid_valid_cell_coords(input_domain):
     test_grid = DomainGrid(input_domain)
 
-    assert test_grid.valid_cell_coords((0, 0))
-    assert test_grid.valid_cell_coords((test_grid.dimensions[0] - 1, test_grid.dimensions[1] - 1))
-    assert test_grid.valid_cell_coords((test_grid.dimensions[0] - 1, 0))
-    assert test_grid.valid_cell_coords((0, test_grid.dimensions[1] - 1))
-    assert test_grid.valid_cell_coords((0, test_grid.dimensions[1] - 1))
-    assert test_grid.valid_cell_coords((test_grid.dimensions[0] - 1, 0))
+    assert test_grid.valid_cell_coords(0, 0)
+    assert test_grid.valid_cell_coords(test_grid.dimensions[0] - 1, test_grid.dimensions[1] - 1)
+    assert test_grid.valid_cell_coords(test_grid.dimensions[0] - 1, 0)
+    assert test_grid.valid_cell_coords(0, test_grid.dimensions[1] - 1)
+    assert test_grid.valid_cell_coords(0, test_grid.dimensions[1] - 1)
+    assert test_grid.valid_cell_coords(test_grid.dimensions[0] - 1, 0)
 
-    assert not test_grid.valid_cell_coords((-1, 0))
-    assert not test_grid.valid_cell_coords((0, -1))
-    assert not test_grid.valid_cell_coords((0, test_grid.dimensions[1]))
-    assert not test_grid.valid_cell_coords((test_grid.dimensions[0], 0))
-    assert not test_grid.valid_cell_coords((test_grid.dimensions[0], test_grid.dimensions[1]))
+    assert not test_grid.valid_cell_coords(-1, 0)
+    assert not test_grid.valid_cell_coords(0, -1)
+    assert not test_grid.valid_cell_coords(0, test_grid.dimensions[1])
+    assert not test_grid.valid_cell_coords(test_grid.dimensions[0], 0)
+    assert not test_grid.valid_cell_coords(test_grid.dimensions[0], test_grid.dimensions[1])
 
 def test_grid_find_cell(input_domain):
     test_grid = DomainGrid(input_domain)

--- a/tests/unit/test_grid/test_domain_grid.py
+++ b/tests/unit/test_grid/test_domain_grid.py
@@ -120,19 +120,9 @@ def test_grid_valid_cell_coords(input_domain):
     assert not test_grid.valid_cell_coords(test_grid.dimensions[0], 0)
     assert not test_grid.valid_cell_coords(test_grid.dimensions[0], test_grid.dimensions[1])
 
-def test_grid_find_cell(input_domain):
+def test_grid_lonlat_to_cell_index(input_domain):
     test_grid = DomainGrid(input_domain)
 
-    # one of xy or lonlat must be provided
-    with pytest.raises(ValueError, match="xy or lonlat must be provided"):
-        test_grid.find_cell()
-    with pytest.raises(ValueError, match="provide only one of xy or lonlat"):
-        test_grid.find_cell(xy=(0, 0), lonlat=(0, 0))
-
-    # coords inside the grid should succeed
-    assert test_grid.find_cell(xy=test_grid.llc_xy) == (0, 0)
-    # fails due to minute error caused by round-tripping
-    # assert test_grid.find_cell(lonlat=test_grid.xy_to_lonlat(*test_grid.llc_xy)) == (0, 0)
-
-    # coords outside the grid should find None
-    assert test_grid.find_cell(xy=(test_grid.llc_xy[0] - 1, test_grid.llc_xy[1])) == None
+    # test some known locations inside aust10km
+    assert test_grid.lonlat_to_cell_index(144.96, -37.78) == (328, 99, True) # Melbourne, VIC
+    assert test_grid.lonlat_to_cell_index(151.18, -33.87) == (388, 135, True) # Sydney, NSW

--- a/tests/unit/test_grid/test_grid.py
+++ b/tests/unit/test_grid/test_grid.py
@@ -156,7 +156,7 @@ def test_grid_valid_cell_coords():
     assert not test_grid.valid_cell_coords(8, 0)
     assert not test_grid.valid_cell_coords(8, 10)
 
-def test_grid_find_cell():
+def test_grid_lonlat_to_cell_index():
     test_grid = Grid(
         dimensions=(8, 10),
         center_lonlat=(45, 45),
@@ -164,37 +164,16 @@ def test_grid_find_cell():
         cell_size=(1, 2),
     )
 
-    # one of xy or lonlat must be provided
-    with pytest.raises(ValueError, match="xy or lonlat must be provided"):
-        test_grid.find_cell()
-    with pytest.raises(ValueError, match="provide only one of xy or lonlat"):
-        test_grid.find_cell(xy=(0, 0), lonlat=(0, 0))
-
-    # coords should be a tuple of ints
-    found = test_grid.find_cell(xy=(41, 40))
-    assert found == (0, 0)
+    # coords should be a tuple (int, int, bool)
+    found = test_grid.lonlat_to_cell_index(41, 40)
+    assert found == (0, 0, True)
     assert type(found) == tuple
 
-    found_x, found_y = found
-    assert type(found_x) == int
-    assert type(found_y) == int
+    found_x, found_y, found_mask = found
+    assert type(found_x) == np.int64
+    assert type(found_y) == np.int64
+    assert type(found_mask) == np.bool_
 
-    # coords inside the grid should succeed
-    assert test_grid.find_cell(xy=(41, 40)) == (0, 0)
-    assert test_grid.find_cell(xy=(45, 45)) == (4, 2)
-    assert test_grid.find_cell(xy=(48.9, 59.9)) == (7, 9)
-
-    assert test_grid.find_cell(xy=test_grid.llc_xy) == (0, 0)
-
-    # coords outside the grid should find None
-    assert test_grid.find_cell(xy=(40.9, 39.9)) == None
-    assert test_grid.find_cell(xy=(40.9, 40.0)) == None
-    assert test_grid.find_cell(xy=(41.0, 39.9)) == None
-    assert test_grid.find_cell(xy=(48.9, 60)) == None
-    assert test_grid.find_cell(xy=(49.0, 59.9)) == None
-    assert test_grid.find_cell(xy=(49.0, 59.9)) == None
-
-def test_grid_lonlat_to_cell_index():
     # set up a grid with a different projection so we can test lon/lat -> x/y conversion
     # using EPSG:7844, which is GDA2020:
     # center: 133.38 -34.51

--- a/tests/unit/test_grid/test_grid.py
+++ b/tests/unit/test_grid/test_grid.py
@@ -144,17 +144,17 @@ def test_grid_valid_cell_coords():
         cell_size=(1, 2),
     )
 
-    assert test_grid.valid_cell_coords((0, 0))
-    assert test_grid.valid_cell_coords((1, 1))
-    assert test_grid.valid_cell_coords((7, 0))
-    assert test_grid.valid_cell_coords((0, 9))
-    assert test_grid.valid_cell_coords((7, 9))
+    assert test_grid.valid_cell_coords(0, 0)
+    assert test_grid.valid_cell_coords(1, 1)
+    assert test_grid.valid_cell_coords(7, 0)
+    assert test_grid.valid_cell_coords(0, 9)
+    assert test_grid.valid_cell_coords(7, 9)
 
-    assert not test_grid.valid_cell_coords((-1, 0))
-    assert not test_grid.valid_cell_coords((0, -1))
-    assert not test_grid.valid_cell_coords((0, 10))
-    assert not test_grid.valid_cell_coords((8, 0))
-    assert not test_grid.valid_cell_coords((8, 10))
+    assert not test_grid.valid_cell_coords(-1, 0)
+    assert not test_grid.valid_cell_coords(0, -1)
+    assert not test_grid.valid_cell_coords(0, 10)
+    assert not test_grid.valid_cell_coords(8, 0)
+    assert not test_grid.valid_cell_coords(8, 10)
 
 def test_grid_find_cell():
     test_grid = Grid(


### PR DESCRIPTION
## Description

The Grid class's liberal use of `@property` actually caused a huge performance regression when properties were used in list and matrix operations over many cells.

This PR replaces `Grid.find_cell` with `Grid.lonlat_to_cell_index` based on @prayner's implementation, which works across DataArrays and np.array. However, when using the Grid method in his `remap_raster` in #42, the function went from 4 second execution to 11 second execution. This appears to have been 100% due to the use of `@property` for derived attributes, as replacing them with simple assignment in the `__init__` method has resolved the performance issue.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
