### PR TITLE
Add optional land masking

### DIFF
--- a/changelog/88.enhancement.md
+++ b/changelog/88.enhancement.md
@@ -1,0 +1,1 @@
+Apply land mask to emissions sources that should only occur on land

--- a/docs/masking.md
+++ b/docs/masking.md
@@ -1,0 +1,58 @@
+
+# Masking data
+
+In data science, masking is the process of subsetting or excluding spatial data
+based on underlying properties.
+
+The most common type of masking in Open Methane is applying a "land mask",
+which is a binary field that describes whether each grid cell covers "land" or
+"sea". In reality, many grid cells may contain both land and sea, but will the
+land mask classify each cell as 100% land or 100% sea due to its binary nature.
+
+## Land masking a spatial proxy
+
+Many sectoral layers in the prior are created by starting with a national total
+for that sector, and using a spatial proxy to determine how to distribute those
+emissions across Australia. Sectors which are generated this way include:
+
+- agriculture
+- lulucf
+- waste
+- industrial
+- stationary
+- transport
+
+The activities in these sectors that emit methane are entirely land-based.
+However, the spatial proxies we use to distribute the emissions, such as the
+NASA night lights TIFF, may have some values over water. We want to avoid
+attributing emissions to a cell that is classified as "sea", as this is likely
+to be a mistake.
+
+For these sectors, we apply the landmask to the source dataset before
+allocating emissions. This ensures that 100% of the inventory emissions are
+allocated to cells within our domain.
+
+## Land masking a coarse dataset
+
+Some sectoral estimates are taken directly from previous studies/datasets that
+have already been spatialised on a grid. These are prepared by regridding the
+source dataset onto the target domain grid. When the source dataset uses
+similar cell size or smaller, we can usually trust that the emissions we
+aggregate into each cell are fine to leave as is.
+
+However, when the source grid is quite coarse (cells that are larger than the
+target grid), grid cells which sit partially over water may be made up of
+cells in the target grid where only a small number are over land. Sectors with
+coarse grids include:
+- termites
+- wetlands
+
+Our current approach for these sectors is to apply the land mask to results
+after regridding, so that cells over water do record methane emission where
+it's very unlikely. This has a downside that some real emissions may be "lost",
+as all the emissions that occur within that large grid cell probably occur in
+the parts of it that are over land.
+
+A smarter approach, which we may pursue in the future, would be to take the
+entire emission estimate from the source grid cell, and allocate it only to
+target grid cells which intersect with the source cell and are not over water.

--- a/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
+++ b/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
@@ -58,6 +58,9 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
 
     om_ntlt = remap_raster(ntlt, config, AREA_OR_POINT=ntlData.AREA_OR_POINT)
 
+    # apply land mask before counting any night lights
+    om_ntlt = om_ntlt * prior_ds["land_mask"]
+
     # we want proportions of total for scaling emissions
     ntltScalar = om_ntlt/om_ntlt.sum()
     sectorData = pd.read_csv(

--- a/src/openmethane_prior/layers/omTermiteEmis.py
+++ b/src/openmethane_prior/layers/omTermiteEmis.py
@@ -188,6 +188,9 @@ def processEmissions(  # noqa: PLR0915
         sector_name="termite",
         sector_data=resultNd,
         sector_standard_name="termites",
+        # source dataset is a coarse grid, cells over water should be
+        # excluded from results because there won't be termites there!
+        apply_landmask=True,
     )
     return resultNd
 

--- a/src/openmethane_prior/layers/omWetlandEmis.py
+++ b/src/openmethane_prior/layers/omWetlandEmis.py
@@ -222,6 +222,9 @@ def processEmissions(
         sector_name="wetlands",
         sector_data=result_xr,
         sector_standard_name="wetland_biological_processes",
+        # source dataset is a coarse grid, and has emissions over ocean which
+        # definitely shouldn't be classified as wetlands
+        apply_landmask=True,
     )
     return result_nd
 

--- a/src/openmethane_prior/outputs.py
+++ b/src/openmethane_prior/outputs.py
@@ -203,6 +203,7 @@ def add_sector(
     sector_data: xr.DataArray | npt.ArrayLike,
     sector_standard_name: str = None,
     sector_long_name: str = None,
+    apply_landmask: bool = False,
 ):
     """
     Write a layer to the output file
@@ -219,6 +220,9 @@ def add_sector(
         CF Conventions suffix to add to the "standard_name" attribute
     sector_long_name
         CF Conventions "long_name" attribute
+    apply_landmask
+        whether or not to mask with domain landmask
+        note this is performed on a copy so data is unchanged
     """
     print(f"Adding emissions data for {sector_name}")
 
@@ -238,6 +242,10 @@ def add_sector(
             dims=COORD_NAMES[:],
             data=expand_sector_dims(sector_data, prior_ds.sizes["time"]),
         )
+
+    if apply_landmask:
+        land_mask = prior_ds['land_mask'].to_numpy()
+        sector_data *= land_mask # should broadcast ok
 
     # enable compression for layer data variables
     sector_data.encoding["zlib"] = True

--- a/tests/integration/test_om_prior.py
+++ b/tests/integration/test_om_prior.py
@@ -81,18 +81,18 @@ def test_009_prior_emissions_ds(prior_emissions_ds):
         "ch4_sector_lulucf": 8.2839841777071689e-13,
         "ch4_sector_waste": 7.680668803420382e-13,
         "ch4_sector_livestock": 3.431944865644255e-12,
-        "ch4_sector_industrial": 4.640887494513728e-15,
-        "ch4_sector_stationary": 8.585641864850578e-14,
-        "ch4_sector_transport": 1.8563549978055247e-14,
+        "ch4_sector_industrial": 4.640887494513727e-15,
+        "ch4_sector_stationary": 8.585641864850575e-14,
+        "ch4_sector_transport": 1.856354997805524e-14,
         "ch4_sector_electricity": 2.3204437472569124e-14,
         "ch4_sector_fugitive": 1.906824649308364e-12,
-        "ch4_sector_termite": 8.106151383815985e-13,
+        "ch4_sector_termite": 7.934378523123675e-13,
         "ch4_sector_fire": 2.6126792244431096e-13,
-        "ch4_sector_wetlands": 1.8596938045956645e-11,
-        "ch4_total": 2.7011865318467605e-11,
+        "ch4_sector_wetlands": 1.6133751762828546e-11,
+        "ch4_total": 2.453150176493793e-11,
 
         # deprecated
-        "OCH4_TOTAL": 2.7011865318467605e-11,
+        "OCH4_TOTAL": 2.453150176493793e-11,
         "LANDMASK": 0.39128163456916809,
     }
 


### PR DESCRIPTION
## Description

Mask some layers using the land mask where emissions are unlikely to occur. This is done in two ways:
- land masking the input data set
- land masking the result after regridding

Both approaches are used based on whether we want to spatialise an existing inventory total (mask the input before spatialising the inventory) or whether we're regridding an existing, coarse dataset (mask the result after regridding).

Resolves #44.

This is equivalent to part of #42, but rebased onto more recent changes in the codebase.

Note: this PR does not include our proposed masking strategy for agriculture, lulucf and waste emissions, where we propose to mask the input dataset prior to spatialising the inventory totals. The existing implementation counts cells with each land use type before regridding, which makes applying the land mask more difficult. This will be addressed in a follow up PR.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
