### PR TITLE
Fix omAgLulucfWasteEmis.py reprojection

### DIFF
--- a/changelog/90.fix.md
+++ b/changelog/90.fix.md
@@ -1,0 +1,1 @@
+Fix reprojection in agriculture, LULUCF and waste layers

--- a/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
+++ b/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
@@ -128,7 +128,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
         sector_xr = xr.DataArray(sector_mask, coords={ 'y': lu_y, 'x': lu_x  })
 
         # now aggregate to coarser resolution of the domain grid
-        sector_gridded = remap_raster(sector_xr, config, input_crs=lu_crs)
+        sector_gridded = remap_raster(sector_xr, config.domain_grid(), input_crs=lu_crs)
 
         # apply land mask before counting any land use
         sector_gridded *= prior_ds["land_mask"]

--- a/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
+++ b/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
@@ -19,9 +19,9 @@
 """Process agriculture, land use and waste methane emissions"""
 
 import csv
-import warnings
 
 import numpy as np
+import rasterio
 import rioxarray as rxr
 import xarray as xr
 from tqdm import tqdm
@@ -33,7 +33,8 @@ from openmethane_prior.outputs import (
     add_sector,
     create_output_dataset, write_output_dataset,
 )
-from openmethane_prior.utils import SECS_PER_YEAR, area_of_rectangle_m2
+from openmethane_prior.utils import SECS_PER_YEAR, mask_array_by_sequence
+from openmethane_prior.raster import remap_raster
 
 sectorEmissionStandardNames = {
     "agriculture": "agricultural_production",
@@ -49,10 +50,6 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
     """
     # Load raster land-use data
     print("processEmissions for Agriculture, LULUCF and waste")
-    print("Loading land use data")
-    landUseData = rxr.open_rasterio(
-        config.as_intermediate_file(config.layer_inputs.land_use_path), masked=True
-    )
 
     ## Calculate livestock CH4
     print("Calculating livestock CH4")
@@ -67,6 +64,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
     cell_x, cell_y, cell_valid = domain_grid.lonlat_to_cell_index(lonmesh, latmesh)
 
     enteric_as_array = lss.CH4_total.to_numpy()
+    livestockCH4Total = enteric_as_array.sum() # for later correcting ag sector
     livestockCH4 = np.zeros(domain_grid.shape)
     print("Distribute livestock CH4 (long process)")
     # we're accumulating emissions from fine to coarse grid
@@ -78,13 +76,12 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
         if mask.any():
             # the following needs to use .at method since iy,ix indices may be repeated and we need to acumulate
             np.add.at(livestockCH4, (iy[mask], ix[mask]), enteric_as_array[j, mask])
-
-    livestockCH4Total = livestockCH4.sum()
     # now convert back to flux not emission units
     livestockCH4 /= domain_grid.cell_area
 
     print("Calculating sectoral emissions")
     # Import a map of land use type numbers to emissions sectors
+    # make a dictionary of all landuse types corresponding to sectors in map
     landuseSectorMap = {}
     sectoral_mapping_file = config.as_input_file(config.layer_inputs.sectoral_mapping_path)
     with open(sectoral_mapping_file, newline="") as f:
@@ -93,84 +90,56 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
 
         for value, sector in reader:
             if sector:
-                landuseSectorMap[int(value)] = sector
-
+                if sector in landuseSectorMap:
+                    landuseSectorMap[sector].append(int(value))
+                else:
+                    landuseSectorMap[sector] = [int(value)]
     # Import a map of emissions per sector, store it to hash table
     methaneInventoryBySector = {}
-    seenHeaders = False
-    headers = []
-
     with open(config.as_input_file(config.layer_inputs.sectoral_emissions_path), newline="") as f:
         reader = csv.reader(f)
-        for row in reader:
-            if not seenHeaders:
-                headers = row.copy()
-                seenHeaders = True
-            else:
-                methaneInventoryBySector = dict.fromkeys(headers, 0)
-                for i, v in enumerate(headers):
-                    ch4 = float(row[i]) * 1e9  # convert Mt to kgs
-                    # subtract the livestock ch4 from agricuture
-                    if v == "agriculture":
-                        ch4 -= livestockCH4Total
-
-                    methaneInventoryBySector[v] = ch4
-
-    # Create a dict to count all of the instances of each sector in the land use data
-    sectorCounts = dict.fromkeys(methaneInventoryBySector, 0)
-
+        headers = next(reader                       ) # first line
+        row = next(reader)
+        methaneInventoryBySector = {h:float(row[i])*1e9 for i,h in enumerate(headers)} # converting from mtCH4 to kgCH4
+    # subtract the livestock ch4 from agriculture
+    methaneInventoryBySector["agriculture"] -= livestockCH4Total
     # Read the land use type data band
-    dataBand = landUseData[0].values
+    print("Loading land use data")
+    # this seems to need two approaches since rioxarray
+    # seems to always convert to float which we don't want but we need it for the other tif attributes
+    landUseData = rxr.open_rasterio(
+        config.as_input_file(config.layer_inputs.land_use_path), masked=True
+    )
+    lu_x = landUseData.x
+    lu_y = landUseData.y
+    lu_crs = landUseData.rio.crs
+    landUseData.close()
 
-    # Count all the unique land-use types
-    unique, counts = np.unique(dataBand, return_counts=True)
-    usageCounts = dict(zip(unique, counts))
+    dataBand = rasterio.open(
+        config.as_input_file(config.layer_inputs.land_use_path),
+        engine='rasterio',
+    ).read()
+    dataBand = dataBand.squeeze()
 
-    # Filter usage counts down to the land use types we have mapped
-    usageCounts = {key: usageCounts[key] for key in landuseSectorMap.keys()}
+    for sector in landuseSectorMap.keys():
+        print(f"Processing land use for sector {sector}")
+        # create a mask of pixels which match the sector code
+        sector_mask = mask_array_by_sequence(dataBand, landuseSectorMap[sector])
+        sector_xr = xr.DataArray(sector_mask, coords={ 'y': lu_y, 'x': lu_x  })
 
-    # Sum the land use counts into sector counts
-    for usageType, count in usageCounts.items():
-        sector = landuseSectorMap.get(int(usageType), False)
-        if sector:
-            sectorCounts[sector] += count
+        # now aggregate to coarser resolution of the domain grid
+        sector_gridded = remap_raster(sector_xr, config, input_crs=lu_crs)
 
-    # Calculate a per grid-square value for each sector
-    sectorEmissionsPerGridSquare = dict.fromkeys(methaneInventoryBySector, 0)
-    sectorsUsed = []
-    for sector, numGridSquares in sectorCounts.items():
-        if numGridSquares != 0:
-            sectorEmissionsPerGridSquare[sector] = methaneInventoryBySector[sector] / numGridSquares
-            sectorsUsed.append(sector)
+        # apply land mask before counting any land use
+        sector_gridded *= prior_ds["land_mask"]
 
-    methane = {}
-    for sector in sectorsUsed:
-        methane[sector] = np.zeros(domain_grid.shape)
+        sector_gridded /=  sector_gridded.sum() # proportion of national emission in each grid square
+        sector_gridded *= methaneInventoryBySector[sector]  # convert to national emissions in kg/gridcell
 
-    print("Mapping land use grid to domain grid")
-    cell_x, cell_y, cell_valid = domain_grid.xy_to_cell_index(landUseData.x, landUseData.y)
-
-    print("Assigning methane layers to domain grid")
-    for landUseType, _ in usageCounts.items():
-        sector = landuseSectorMap[landUseType]
-        emission = sectorEmissionsPerGridSquare[sector]
-        sectorPixels = np.argwhere(dataBand == landUseType)
-
-        if emission > 0:
-            for y, x in sectorPixels:
-                try:
-                    ix, iy = cell_x.item(x), cell_y.item(y)
-                    methane[sector][iy, ix] += emission
-                except IndexError:
-                    # print("ignoring out of range pixel")
-                    pass  # it's outside our domain
-
-    print("Writing sectoral methane layers output file")
-    for sector in sectorsUsed:
         add_sector(
             prior_ds=prior_ds,
             sector_name=sector.lower(),
-            sector_data=convert_to_timescale(methane[sector], cell_area=domain_grid.cell_area),
+            sector_data=convert_to_timescale(sector_gridded, cell_area=domain_grid.cell_area),
             sector_standard_name=sectorEmissionStandardNames[sector],
         )
 

--- a/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
+++ b/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
@@ -56,7 +56,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     ntlt = ntlData.sum(axis=0)
     np.nan_to_num(ntlt, copy=False)
 
-    om_ntlt = remap_raster(ntlt, config, AREA_OR_POINT=ntlData.AREA_OR_POINT)
+    om_ntlt = remap_raster(ntlt, config.domain_grid(), AREA_OR_POINT=ntlData.AREA_OR_POINT)
 
     # apply land mask before counting any night lights
     om_ntlt = om_ntlt * prior_ds["land_mask"]

--- a/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
+++ b/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
@@ -62,13 +62,15 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     om_ntlt = om_ntlt * prior_ds["land_mask"]
 
     # we want proportions of total for scaling emissions
-    ntltScalar = om_ntlt/om_ntlt.sum()
-    sectorData = pd.read_csv(
+    om_ntlt_proportion = om_ntlt / om_ntlt.sum()
+
+    sector_totals = pd.read_csv(
         config.as_input_file(config.layer_inputs.sectoral_emissions_path)
     ).to_dict(orient="records")[0]
     methane = {}
     for sector in sectorsUsed:
-        methane[sector] = ntltScalar * sectorData[sector] * 1e9
+        # allocate the proportion of the total to each grid cell
+        methane[sector] = om_ntlt_proportion * sector_totals[sector] * 1e9
         add_sector(
             prior_ds=prior_ds,
             sector_name=sector.lower(),

--- a/src/openmethane_prior/raster.py
+++ b/src/openmethane_prior/raster.py
@@ -89,7 +89,7 @@ def remap_raster(
     # we accumulate values from each high-res grid in the raster onto our domain then divide by the number
     # our criterion is that the central point in the high-res lies inside the cell defined on the grid
     # get input coordinates and resolutions, these are not retained in this data structure despite presence in underlying tiff file
-    input_field_np = input_field.to_numpy()
+    input_field_np = input_field.to_numpy().squeeze()
 
     # the following needs .to_numpy() because
     # subtracting xarray matches coordinates, not what we want

--- a/src/openmethane_prior/raster.py
+++ b/src/openmethane_prior/raster.py
@@ -84,7 +84,6 @@ def remap_raster(
     domain_grid = config.domain_grid()
 
     result = np.zeros(domain_grid.shape)
-    count = np.zeros_like(result)
 
     # we accumulate values from each high-res grid in the raster onto our domain then divide by the number
     # our criterion is that the central point in the high-res lies inside the cell defined on the grid
@@ -114,9 +113,5 @@ def remap_raster(
         if mask.any():
             # the following needs to use .at method since cell_y,cell_x indices may be repeated and we need to acumulate
             np.add.at(result, (cell_y[mask], cell_x[mask]), input_field_np[j, mask])
-            np.add.at(count, (cell_y[mask], cell_x[mask]),  1)
-
-    has_vals = count > 0
-    result[has_vals] /= count[has_vals]
 
     return result

--- a/src/openmethane_prior/utils.py
+++ b/src/openmethane_prior/utils.py
@@ -158,3 +158,16 @@ def bounds_from_cell_edges(cell_edges: xr.DataArray) -> np.array:
     lower_bounds = cell_edges[:-1]
     upper_bounds = cell_edges[1:]
     return np.column_stack([lower_bounds, upper_bounds])
+
+
+def mask_array_by_sequence(
+    array: np.ndarray,
+    sequence: list|tuple|str,
+) -> np.ndarray:
+    """
+    Returns true for all elements that match any member of sequence
+    """
+    result = np.zeros_like(array).astype('int')
+    for s in sequence:
+        result[(array==s)] = True
+    return result

--- a/tests/integration/test_om_prior.py
+++ b/tests/integration/test_om_prior.py
@@ -81,7 +81,7 @@ def test_009_prior_emissions_ds(prior_emissions_ds):
         "ch4_sector_lulucf": 8.2839841777071689e-13,
         "ch4_sector_waste": 7.680668803420382e-13,
         "ch4_sector_livestock": 3.431944865644255e-12,
-        "ch4_sector_industrial": 4.640887494513727e-15,
+        "ch4_sector_industrial": 4.640887494513728e-15,
         "ch4_sector_stationary": 8.585641864850575e-14,
         "ch4_sector_transport": 1.856354997805524e-14,
         "ch4_sector_electricity": 2.3204437472569124e-14,
@@ -89,10 +89,10 @@ def test_009_prior_emissions_ds(prior_emissions_ds):
         "ch4_sector_termite": 7.934378523123675e-13,
         "ch4_sector_fire": 2.6126792244431096e-13,
         "ch4_sector_wetlands": 1.6133751762828546e-11,
-        "ch4_total": 2.453150176493793e-11,
+        "ch4_total": 2.453150176493794e-11,
 
         # deprecated
-        "OCH4_TOTAL": 2.453150176493793e-11,
+        "OCH4_TOTAL": 2.453150176493794e-11,
         "LANDMASK": 0.39128163456916809,
     }
 

--- a/tests/integration/test_om_prior.py
+++ b/tests/integration/test_om_prior.py
@@ -77,9 +77,9 @@ def test_009_prior_emissions_ds(prior_emissions_ds):
         "x_bounds": 0.0,
         "y_bounds": 0.02444604212461516,
         "land_mask": 0.39128163098043234,
-        "ch4_sector_agriculture": 2.7554413153547755e-13,
-        "ch4_sector_lulucf": 8.2839841777071689e-13,
-        "ch4_sector_waste": 7.680668803420382e-13,
+        "ch4_sector_agriculture": 2.755457150919664e-13,
+        "ch4_sector_lulucf": 8.283984177707171e-13,
+        "ch4_sector_waste": 7.680668803420377e-13,
         "ch4_sector_livestock": 3.431944865644255e-12,
         "ch4_sector_industrial": 4.640887494513728e-15,
         "ch4_sector_stationary": 8.585641864850575e-14,
@@ -89,10 +89,10 @@ def test_009_prior_emissions_ds(prior_emissions_ds):
         "ch4_sector_termite": 7.934378523123675e-13,
         "ch4_sector_fire": 2.6126792244431096e-13,
         "ch4_sector_wetlands": 1.6133751762828546e-11,
-        "ch4_total": 2.453150176493794e-11,
+        "ch4_total": 2.4531503348494433e-11,
 
         # deprecated
-        "OCH4_TOTAL": 2.453150176493794e-11,
+        "OCH4_TOTAL": 2.4531503348494433e-11,
         "LANDMASK": 0.39128163456916809,
     }
 

--- a/tests/unit/test_raster.py
+++ b/tests/unit/test_raster.py
@@ -22,7 +22,7 @@ def test_remap_raster(config, input_files):
     ntl *= 0.
     ntl[test_coord] = 1.
     # now clip to remove offshore lights
-    om_ntl = remap_raster(ntl, config, AREA_OR_POINT = ntl_raw.AREA_OR_POINT)
+    om_ntl = remap_raster(ntl, config.domain_grid(), AREA_OR_POINT = ntl_raw.AREA_OR_POINT)
 
     # now a few tests on outputs
     # only one nonzero point in output

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,7 +5,8 @@ import pytest
 import sys
 import xarray as xr
 
-from openmethane_prior.utils import get_command, get_timestamped_command, time_bounds, bounds_from_cell_edges
+from openmethane_prior.utils import get_command, get_timestamped_command, time_bounds, bounds_from_cell_edges, \
+    mask_array_by_sequence
 
 
 def test_get_command():
@@ -51,3 +52,16 @@ def test_bounds_from_cell_edges():
     assert len(bounds) == len(edges) - 1
     assert list(bounds[0]) == [edges[0], edges[1]]
     assert list(bounds[-1]) == [edges[-2], edges[-1]]
+
+
+def test_mask_array_by_sequence():
+    test_array = np.array([1, 2, 3, 4, 5, 6])
+
+    np.testing.assert_array_equal(
+        mask_array_by_sequence(test_array, [2, 4, 6]),
+        [False, True, False, True, False, True],
+    )
+    np.testing.assert_array_equal(
+        mask_array_by_sequence(test_array, (2, 4, 6)),
+        [False, True, False, True, False, True],
+    )


### PR DESCRIPTION
## Description

Previously, the omAgLulucfWasteEmis.py module was using an intermediate reprojected version of the Australian land use file, which was generated using the wrong projection.

This PR adapts the `remap_raster` utility to allow an alternative input CRS to be specified, so that we can use the utility to regrid the land use raster onto the domain grid. The result then has the land mask applied so that all sectoral emissions are applied within valid land pixels.

Based on commits originally authored by @prayner in #42.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
