### PR TITLE
Remove intermediate reprojections which are no longer used

### DIFF
--- a/changelog/99.bug.md
+++ b/changelog/99.bug.md
@@ -1,0 +1,1 @@
+Remove intermediates generated with reproject_tiff which are no longer used

--- a/scripts/omPrior.py
+++ b/scripts/omPrior.py
@@ -32,7 +32,6 @@ from openmethane_prior.layers import (
     omWetlandEmis,
 )
 from openmethane_prior.outputs import add_ch4_total, create_output_dataset, write_output_dataset
-from openmethane_prior.raster import reproject_raster_inputs
 from openmethane_prior.verification import verify_emis
 import openmethane_prior.logger as logger
 
@@ -57,9 +56,6 @@ def run_prior(config: PriorConfig):
 
     # Initialise the output dataset based on the domain provided in config
     prior_ds = create_output_dataset(config)
-
-    if not config.skip_reproject:
-        reproject_raster_inputs(config)
 
     omAgLulucfWasteEmis.processEmissions(config, prior_ds)
     omIndustrialStationaryTransportEmis.processEmissions(config, prior_ds)

--- a/src/openmethane_prior/config.py
+++ b/src/openmethane_prior/config.py
@@ -92,7 +92,6 @@ class PriorConfigOptions(typing.TypedDict, total=False):
     layer_inputs: LayerInputs
     start_date: datetime.datetime
     end_date: datetime.datetime
-    skip_reproject: bool
 
 @attrs.frozen
 class PriorConfig:
@@ -118,8 +117,6 @@ class PriorConfig:
 
     start_date: datetime.datetime | None = None
     end_date: datetime.datetime | None = None
-
-    skip_reproject: bool = False
 
     def as_input_file(self, name: str | pathlib.Path) -> pathlib.Path:
         """Return the full path to an input file"""
@@ -222,7 +219,6 @@ def load_config_from_env(**overrides: PriorConfigOptions) -> PriorConfig:
         start_date=env.datetime("START_DATE", None),
         # if END_DATE not set, use START_DATE for a 1-day run
         end_date=env.datetime("END_DATE", None) or env.datetime("START_DATE", None),
-        skip_reproject=env.bool("SKIP_REPROJECT", False),
     )
 
     return PriorConfig(**{**options, **overrides})
@@ -266,5 +262,3 @@ def parse_cli_to_env():
         os.environ["END_DATE"] = args.end_date.strftime("%Y-%m-%d")
     elif args.start_date is not None:
         os.environ["END_DATE"] = args.start_date.strftime("%Y-%m-%d")
-
-    os.environ["SKIP_REPROJECT"] = "True" if args.skip_reproject else "False"

--- a/src/openmethane_prior/raster.py
+++ b/src/openmethane_prior/raster.py
@@ -1,77 +1,8 @@
-import os
 import numpy as np
 import pyproj
-import rasterio as rio
-from rasterio.warp import Resampling, calculate_default_transform, reproject
 import xarray as xr
 
-from openmethane_prior.config import PriorConfig
 from openmethane_prior.grid.grid import Grid
-
-
-def reproject_tiff(image, output, dst_crs="EPSG:4326", resampling="nearest", **kwargs):
-    """Reprojects an image.
-
-    Based on samgeo.common.reproject
-
-    Args:
-        image (str): The input image filepath.
-        output (str): The output image filepath.
-        dst_crs (str, optional): The destination CRS. Defaults to "EPSG:4326".
-        resampling (Resampling, optional): The resampling method. Defaults to "nearest".
-        **kwargs: Additional keyword arguments to pass to rasterio.open.
-
-    """
-    if isinstance(resampling, str):
-        resampling = getattr(Resampling, resampling)
-
-    image = os.path.abspath(image)
-    output = os.path.abspath(output)
-
-    if not os.path.exists(os.path.dirname(output)):
-        os.makedirs(os.path.dirname(output))
-
-    with rio.open(image, **kwargs) as src:
-        transform, width, height = calculate_default_transform(
-            src.crs, dst_crs, src.width, src.height, *src.bounds
-        )
-        kwargs = src.meta.copy()
-        kwargs.update(
-            {
-                "crs": dst_crs,
-                "transform": transform,
-                "width": width,
-                "height": height,
-            }
-        )
-
-        with rio.open(output, "w", **kwargs) as dst:
-            for i in range(1, src.count + 1):
-                reproject(
-                    source=rio.band(src, i),
-                    destination=rio.band(dst, i),
-                    src_transform=src.transform,
-                    src_crs=src.crs,
-                    dst_transform=transform,
-                    dst_crs=dst_crs,
-                    resampling=resampling,
-                    **kwargs,
-                )
-
-
-def reproject_raster_inputs(config: PriorConfig):
-    """Re-project raster files to match domain"""
-    print("### Re-projecting raster inputs...")
-    reproject_tiff(
-        str(config.as_input_file(config.layer_inputs.land_use_path)),
-        str(config.as_intermediate_file(config.layer_inputs.land_use_path)),
-        config.crs,
-    )
-    reproject_tiff(
-        str(config.as_input_file(config.layer_inputs.ntl_path)),
-        str(config.as_intermediate_file(config.layer_inputs.ntl_path)),
-        config.crs,
-    )
 
 
 def remap_raster(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,7 +220,6 @@ def prior_emissions_ds(
         output_path=output_dir,
         start_date=start_date,
         end_date=end_date,
-        skip_reproject=False,
         # Use the test domain to speed things up
         # input_domain=PublishedInputDomain(
         #     name="aust-test",


### PR DESCRIPTION
## Description

Because of the consistent shape of the domain grid and source data files, we have previously cached the result of regridding/reprojecting large input files into the domain grid.

However, both of the intermediate reprojections generated by `reproject_tiff` were problematic, and led to subtle bugs that have now been fixed. Although it would be possible to store the output of the new reprojections for re-use, this hasn't been actioned. In the meantime, these intermediate reprojections should not be re-created as it is a waste of time and CPU resources.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
