### PR TITLE
Add `logger` util to replace `print` statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,28 @@ and end date as below):
 poetry run python src/openmethane_prior/layers/omWetlandEmis.py --start-date 2022-07-01 --end-date 2022-07-01
 ```
 
+### Console output
+
+The detail of console output can be controlled by setting the `LOG_LEVEL` env
+variable. By default, this is set to `INFO`, but more or less can be achieved
+by setting other log levels:
+
+```shell
+# verbose debug output
+LOG_LEVEL=DEBUG poetry run python scripts/omPrior.py --start-date 2022-07-01 --end-date 2022-07-01
+
+# only warnings and errors
+LOG_LEVEL=WARNING poetry run python scripts/omPrior.py --start-date 2022-07-01 --end-date 2022-07-01
+```
+
+Log output can also be written to a file while still logging to the console
+with the `LOG_FILE` env variable.
+
+```shell
+LOG_FILE=/var/log/prior.log poetry run python scripts/omPrior.py --start-date 2022-07-01 --end-date 2022-07-01
+```
+
+
 ## Outputs
 
 Outputs can be found in the `data/outputs` folder. The emissions layers will be written as variables to a copy of the

--- a/changelog/100.improvement.md
+++ b/changelog/100.improvement.md
@@ -1,0 +1,1 @@
+Replace print statements with configurable logger

--- a/scripts/omPrior.py
+++ b/scripts/omPrior.py
@@ -17,7 +17,7 @@
 #
 
 """Main entry point for running the openmethane-prior"""
-
+import logging
 import prettyprinter
 
 from openmethane_prior.config import PriorConfig, load_config_from_env, parse_cli_to_env
@@ -34,6 +34,9 @@ from openmethane_prior.layers import (
 from openmethane_prior.outputs import add_ch4_total, create_output_dataset, write_output_dataset
 from openmethane_prior.raster import reproject_raster_inputs
 from openmethane_prior.verification import verify_emis
+import openmethane_prior.logger as logger
+
+logger = logger.get_logger(__name__)
 
 prettyprinter.install_extras(["attrs"])
 
@@ -77,7 +80,7 @@ if __name__ == "__main__":
     parse_cli_to_env()
     config = load_config_from_env()
 
-    print("Configuration:")
-    prettyprinter.cpprint(config)
+    if logger.level <= logging.DEBUG:
+        prettyprinter.cpprint(config)
 
     run_prior(config)

--- a/src/openmethane_prior/inputs.py
+++ b/src/openmethane_prior/inputs.py
@@ -66,7 +66,7 @@ def download_input_file(remote_url: str, url_fragment: str, save_path: pathlib.P
 
         return True
     else:
-        logger.debug(f"Skipping {url_fragment} because it already exists at {save_path}")
+        logger.info(f"Skipping {url_fragment} because it already exists at {save_path}")
 
     return False
 

--- a/src/openmethane_prior/inputs.py
+++ b/src/openmethane_prior/inputs.py
@@ -19,7 +19,6 @@
 
 import os
 import pathlib
-import sys
 import urllib.parse
 import requests
 
@@ -108,4 +107,4 @@ def check_input_files(config: PriorConfig):
             "The default input set can be fetched by running omDownloadInputs.py. "
             f"\nMissing inputs:{''.join(errors)}"
         )
-        sys.exit(1)
+        raise ValueError("Required inputs are missing")

--- a/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
+++ b/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
@@ -35,6 +35,9 @@ from openmethane_prior.outputs import (
 )
 from openmethane_prior.utils import SECS_PER_YEAR, mask_array_by_sequence
 from openmethane_prior.raster import remap_raster
+import openmethane_prior.logger as logger
+
+logger = logger.get_logger(__name__)
 
 sectorEmissionStandardNames = {
     "agriculture": "agricultural_production",
@@ -49,10 +52,10 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
     dataset.
     """
     # Load raster land-use data
-    print("processEmissions for Agriculture, LULUCF and waste")
+    logger.info("processEmissions for Agriculture, LULUCF and waste")
 
     ## Calculate livestock CH4
-    print("Calculating livestock CH4")
+    logger.info("Calculating livestock CH4")
     with xr.open_dataset(config.as_input_file(config.layer_inputs.livestock_path)) as lss:
         ls = lss.load()
 
@@ -66,7 +69,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
     enteric_as_array = lss.CH4_total.to_numpy()
     livestockCH4Total = enteric_as_array.sum() # for later correcting ag sector
     livestockCH4 = np.zeros(domain_grid.shape)
-    print("Distribute livestock CH4 (long process)")
+    logger.info("Distribute livestock CH4 (long process)")
     # we're accumulating emissions from fine to coarse grid
     # accumulate in mass units and divide by area at end
     for j in tqdm(range(ls.lat.size)):
@@ -79,7 +82,6 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
     # now convert back to flux not emission units
     livestockCH4 /= domain_grid.cell_area
 
-    print("Calculating sectoral emissions")
     # Import a map of land use type numbers to emissions sectors
     # make a dictionary of all landuse types corresponding to sectors in map
     landuseSectorMap = {}
@@ -104,7 +106,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
     # subtract the livestock ch4 from agriculture
     methaneInventoryBySector["agriculture"] -= livestockCH4Total
     # Read the land use type data band
-    print("Loading land use data")
+    logger.debug("Loading land use data")
     # this seems to need two approaches since rioxarray
     # seems to always convert to float which we don't want but we need it for the other tif attributes
     landUseData = rxr.open_rasterio(
@@ -122,7 +124,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
     dataBand = dataBand.squeeze()
 
     for sector in landuseSectorMap.keys():
-        print(f"Processing land use for sector {sector}")
+        logger.debug(f"Processing land use for sector {sector}")
         # create a mask of pixels which match the sector code
         sector_mask = mask_array_by_sequence(dataBand, landuseSectorMap[sector])
         sector_xr = xr.DataArray(sector_mask, coords={ 'y': lu_y, 'x': lu_x  })
@@ -143,7 +145,6 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
             sector_standard_name=sectorEmissionStandardNames[sector],
         )
 
-    print("Writing livestock methane layers output file")
     # convert the livestock data from per year to per second and write
     livestock_ch4_s = livestockCH4 / SECS_PER_YEAR
     add_sector(

--- a/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
+++ b/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
@@ -24,7 +24,6 @@ import numpy as np
 import rasterio
 import rioxarray as rxr
 import xarray as xr
-from tqdm import tqdm
 
 from openmethane_prior.config import PriorConfig, load_config_from_env, parse_cli_to_env
 from openmethane_prior.outputs import (
@@ -72,7 +71,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
     logger.info("Distribute livestock CH4 (long process)")
     # we're accumulating emissions from fine to coarse grid
     # accumulate in mass units and divide by area at end
-    for j in tqdm(range(ls.lat.size)):
+    for j in range(ls.lat.size):
         ix, iy = cell_x[j,:], cell_y[j,:]
         # input domain is bigger so mask indices out of range
         mask = cell_valid[j, :]

--- a/src/openmethane_prior/layers/omElectricityEmis.py
+++ b/src/openmethane_prior/layers/omElectricityEmis.py
@@ -30,13 +30,16 @@ from openmethane_prior.outputs import (
     create_output_dataset,
     write_output_dataset,
 )
+import openmethane_prior.logger as logger
+
+logger = logger.get_logger(__name__)
 
 def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     """
     Process emissions from the electricity sector, adding them to the prior
     dataset.
     """
-    print("processEmissions for Electricity")
+    logger.info("processEmissions for electricity")
 
     electricityEmis = (
         pd.read_csv(config.as_input_file(config.layer_inputs.sectoral_emissions_path)).to_dict(

--- a/src/openmethane_prior/layers/omFugitiveEmis.py
+++ b/src/openmethane_prior/layers/omFugitiveEmis.py
@@ -30,7 +30,9 @@ from openmethane_prior.outputs import (
     create_output_dataset,
     write_output_dataset,
 )
+import openmethane_prior.logger as logger
 
+logger = logger.get_logger(__name__)
 
 def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     """
@@ -38,7 +40,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
 
     Adds the ch4_fugitive layer to the output
     """
-    print("processEmissions for fugitives")
+    logger.info("processEmissions for fugitives")
     fugitiveEmis = pd.read_csv(
         config.as_input_file(config.layer_inputs.sectoral_emissions_path)
     ).to_dict(orient="records")[0]["fugitive"]  # national total from inventory

--- a/src/openmethane_prior/layers/omGFASEmis.py
+++ b/src/openmethane_prior/layers/omGFASEmis.py
@@ -44,7 +44,9 @@ from openmethane_prior.utils import (
     redistribute_spatially,
     save_zipped_pickle,
 )
+import openmethane_prior.logger as logger
 
+logger = logger.get_logger(__name__)
 
 def download_GFAS(
     start_date: datetime.date,
@@ -108,7 +110,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset, forceUpdate: boo
     nlonGfas = len(lonGfas)
     nlatGfas = len(latGfas)
 
-    print("Calculate grid cell areas for the GFAS grid")
+    logger.debug("Calculate grid cell areas for the GFAS grid")
     GFASAreas = np.zeros((nlatGfas, nlonGfas))
     # take advantage of  regular grid to compute areas equal for each gridbox at same latitude
     for iy in range(nlatGfas):

--- a/src/openmethane_prior/layers/omGFASEmis.py
+++ b/src/openmethane_prior/layers/omGFASEmis.py
@@ -62,7 +62,7 @@ def download_GFAS(
     downloadPath = pathlib.Path(file_name);
     downloadPath.parent.mkdir(parents=True, exist_ok=True)
 
-    c = cdsapi.Client()
+    c = cdsapi.Client(progress=False)
 
     c.retrieve(
         "cams-global-fire-emissions-gfas",

--- a/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
+++ b/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
@@ -32,6 +32,9 @@ from openmethane_prior.outputs import (
     write_output_dataset,
 )
 from openmethane_prior.raster import remap_raster
+import openmethane_prior.logger as logger
+
+logger = logger.get_logger(__name__)
 
 sectorEmissionStandardNames = {
     "industrial": "industrial_processes_and_combustion",
@@ -45,7 +48,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     Process emissions for Industrial, Stationary and Transport sectors, adding
     them to the prior dataset.
     """
-    print("processEmissions for Industrial, Stationary and Transport")
+    logger.info("processEmissions for Industrial, Stationary and Transport")
 
     sectorsUsed = ["industrial", "stationary", "transport"]
 

--- a/src/openmethane_prior/logger.py
+++ b/src/openmethane_prior/logger.py
@@ -1,0 +1,77 @@
+#
+# Copyright 2025 The Superpower Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import logging
+import os
+import pathlib
+
+def _parse_logger_env():
+    """
+    Parses environment variables and sets up logging based on their values.
+
+    LOG_LEVEL - must be a valid logging level from the builtin logging package.
+      Sets the log level of the base logger and all logs accessed via get_logger.
+
+    LOG_FILE - a filename where the logger should attempt to log. If the
+      provided filename already exists, it will attempt to move the existing
+      file by prefixing the filename with `000`, `001`, etc.
+
+    :return: (log_level, log_file_handler)
+    """
+    LOG_LEVEL = os.getenv("LOG_LEVEL", None)
+
+    # Set a default log level based on the LOG_LEVEL environment var
+    log_level = logging.INFO
+    if LOG_LEVEL is not None:
+        log_levels = logging.getLevelNamesMapping()
+        if LOG_LEVEL in log_levels.keys():
+            log_level = log_levels[LOG_LEVEL]
+        else:
+            valid_levels = ', '.join(log_levels.keys())
+            logging.warning(
+                f"LOG_LEVEL={LOG_LEVEL} is not a valid log level, must be one of: {valid_levels}"
+            )
+
+    # Log to a file if a filename is provided in the LOG_FILE environment var
+    log_file = os.getenv("LOG_FILE", None)
+    if log_file is not None:
+        # if a file already exists at that path, move it
+        if os.path.isfile(log_file):
+            file_dir = os.path.dirname(log_file)
+            file_name = os.path.basename(log_file)
+            rotation = 0
+            rotate_log_name = pathlib.Path(file_dir, f"{f'{rotation:03d}'}.{file_name}")
+            while os.path.exists(rotate_log_name):
+                rotation += 1
+                rotate_log_name = pathlib.Path(file_dir, f"{f'{rotation:03d}'}.{file_name}")
+            os.rename(log_file, rotate_log_name)
+
+    return log_level, log_file
+
+# configure logging automatically when this module is invoked
+log_level, log_file = _parse_logger_env()
+logging.basicConfig(level=log_level)
+
+def get_logger(package_name: str) -> logging.Logger:
+    logger = logging.getLogger(package_name)
+    logger.setLevel(log_level)
+
+    # add file handler so log output goes to the terminal and the file
+    if log_file is not None:
+        logger.addHandler(logging.FileHandler(log_file))
+
+    return logger
+
+

--- a/src/openmethane_prior/outputs.py
+++ b/src/openmethane_prior/outputs.py
@@ -23,6 +23,9 @@ from openmethane_prior.cell_name import encode_grid_cell_name
 from openmethane_prior.config import PriorConfig
 from openmethane_prior.utils import SECS_PER_YEAR, get_version, get_timestamped_command, time_bounds, \
     bounds_from_cell_edges
+import openmethane_prior.logger as logger
+
+logger = logger.get_logger(__name__)
 
 COORD_NAMES = ["time", "vertical", "y", "x"]
 PROJECTION_VAR_NAME = "lambert_conformal"
@@ -224,7 +227,7 @@ def add_sector(
         whether or not to mask with domain landmask
         note this is performed on a copy so data is unchanged
     """
-    print(f"Adding emissions data for {sector_name}")
+    logger.info(f"Adding emissions data for {sector_name}")
 
     # determine the expected shape of a data layer based on the assumed coords
     expected_shape = tuple([(prior_ds.sizes[coord_name] if coord_name in prior_ds.sizes else 1) for coord_name in COORD_NAMES])

--- a/src/openmethane_prior/verification.py
+++ b/src/openmethane_prior/verification.py
@@ -26,6 +26,9 @@ from colorama import Fore
 from openmethane_prior.config import PriorConfig, load_config_from_env
 from openmethane_prior.outputs import SECTOR_PREFIX
 from openmethane_prior.utils import SECS_PER_YEAR
+import openmethane_prior.logger as logger
+
+logger = logger.get_logger(__name__)
 
 MAX_ABS_DIFF = 0.1
 
@@ -36,47 +39,45 @@ def verify_emis(config: PriorConfig, prior_ds: xr.Dataset, atol: float = MAX_ABS
         config.as_input_file(config.layer_inputs.sectoral_emissions_path)
     ).to_dict(orient="records")[0]
 
+    passed = []
+    failed = []
+
     # Load Livestock inventory and check that it doesn't exceed total agriculture inventory
     with xr.open_dataset(config.as_input_file(config.layer_inputs.livestock_path)) as lss:
         ls = lss.load()
-    lsVal = round(np.sum(ls["CH4_total"].values))
-    agVal = round(sector_data["agriculture"] * 1e9)
-    agDX = agVal - lsVal
+    livestock_inventory_total = round(np.sum(ls["CH4_total"].values))
+    agriculture_inventory_total = round(sector_data["agriculture"] * 1e9)
+    agriculture_remaining = (agriculture_inventory_total - livestock_inventory_total) / 1e9
 
-    if agDX > 0:
-        print(
-            f"{Fore.GREEN}PASSED - "
-            f"Livestock CH4 within bounds of total agriculture CH4: {agDX / 1e9}"
-        )
+    if agriculture_remaining > 0:
+        passed.append(f"Livestock CH4 within bounds of total agriculture CH4: {agriculture_remaining}")
     else:
-        print(
-            f"{Fore.RED}FAILED - "
-            f"Livestock CH4 exceeds bounds of total agriculture CH4: {agDX / 1e9}"
-        )
+        failed.append(f"Livestock CH4 exceeds bounds of total agriculture CH4: {agriculture_remaining}")
 
     # Check each layer in the output sums up to the input
-    modelAreaM2 = config.domain_grid().cell_area
+    m2s_to_kg = config.domain_grid().cell_area * SECS_PER_YEAR
     for sector in sector_data.keys():
         layerName = f"{SECTOR_PREFIX}_{sector}"
         sectorVal = float(sector_data[sector]) * 1e9
 
         if layerName in prior_ds:
-            layerVal = np.sum(prior_ds[layerName][0].values * modelAreaM2 * SECS_PER_YEAR)
+            layerVal = np.sum(prior_ds[layerName][0].values * m2s_to_kg)
 
             if sector == "agriculture":
-                layerVal += np.sum(prior_ds[f"{SECTOR_PREFIX}_livestock"][0].values * modelAreaM2 * SECS_PER_YEAR)
+                layerVal += np.sum(prior_ds[f"{SECTOR_PREFIX}_livestock"][0].values * m2s_to_kg)
 
             diff = round(layerVal - sectorVal)
             pct_diff = diff / sectorVal * 100
 
             if abs(pct_diff) > atol:
-                print(f"{Fore.RED}FAILED - " f"Discrepancy of {pct_diff}% in {sector} emissions{Fore.RESET}")
+                failed.append(f"Discrepancy of {pct_diff}% in {sector} emissions")
             else:
-                print(
-                    f"{Fore.GREEN}PASSED - "
-                    f"{sector} emissions OK, discrepancy is {abs(pct_diff)}% of total{Fore.RESET}"
-                )
+                passed.append(f"{sector} emissions OK, discrepancy is {abs(pct_diff)}% of total")
 
+    for passed_msg in passed:
+        logger.debug(f"{Fore.GREEN}PASSED{Fore.RESET} - {passed_msg}")
+    for failed_msg in failed:
+        logger.warning(f"{Fore.RED}FAILED{Fore.RESET} - {failed_msg}")
 
 if __name__ == "__main__":
     config = load_config_from_env()

--- a/tests/integration/test_om_prior.py
+++ b/tests/integration/test_om_prior.py
@@ -16,8 +16,7 @@ def test_001_response_for_download_links(config):
     for file_fragment in layer_info.values():
         url = f"{config.remote}{file_fragment}"
         with requests.get(url, stream=True, timeout=30) as response:
-            print(f"Response code for {url}: {response.status_code}")
-            assert response.status_code == 200
+            assert response.status_code == 200, f"Unexpected {response.status_code} response for: {url}"
 
 
 @pytest.mark.skip(reason="Duplicated by other tests")

--- a/tests/unit/test_inputs.py
+++ b/tests/unit/test_inputs.py
@@ -1,5 +1,8 @@
+import logging
+
 import pytest
 
+from openmethane_prior.config import PriorConfig
 from openmethane_prior.inputs import check_input_files
 from scripts.omDownloadInputs import download_input_files
 
@@ -9,15 +12,13 @@ def test_download_non_relative(tmp_path):
         download_input_files("http://example.com", tmp_path, ["../etc/passwd"])
 
 
-def test_check_inputs_missing(config, capsys):
+def test_check_inputs_missing(config: PriorConfig, caplog: pytest.LogCaptureFixture):
     with pytest.raises(SystemExit):
         check_input_files(config)
 
-    stdout = capsys.readouterr().out
-
-    assert "Some required files are missing" in stdout
-    assert "Missing file for domain info at" in stdout
-    assert "Missing file for termite data at termite_emissions_2010-2016.nc" in stdout
+    assert "Required inputs are missing" in caplog.text
+    assert "(domain info)" in caplog.text
+    assert f"{config.layer_inputs.termite_path} (termite data)" in caplog.text
 
 
 def test_check_inputs(config, input_files):

--- a/tests/unit/test_inputs.py
+++ b/tests/unit/test_inputs.py
@@ -13,7 +13,7 @@ def test_download_non_relative(tmp_path):
 
 
 def test_check_inputs_missing(config: PriorConfig, caplog: pytest.LogCaptureFixture):
-    with pytest.raises(SystemExit):
+    with pytest.raises(ValueError):
         check_input_files(config)
 
     assert "Required inputs are missing" in caplog.text
@@ -23,6 +23,3 @@ def test_check_inputs_missing(config: PriorConfig, caplog: pytest.LogCaptureFixt
 
 def test_check_inputs(config, input_files):
     check_input_files(config)
-
-
-


### PR DESCRIPTION
## Description

This brings the `logger` util from openmethane to provide consistent handling of console output based on the `LOG_LEVEL` env var.

All `print()` statements have been replaced with `logger.info` or `logger.debug` based on whether a user would expect to see that input during normal operation, or whether it's more useful during development.

Some output that doesn't come from `print` (such as dumping the config to screen) is now conditional based on the log level.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
