### PR TITLE
Fix incorrectly apply inventory mask to different sized domain

### DIFF
--- a/src/openmethane_prior/grid/regrid.py
+++ b/src/openmethane_prior/grid/regrid.py
@@ -1,0 +1,49 @@
+#
+# Copyright 2025 The Superpower Institute Ltd.
+#
+# This file is part of Open Methane.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import itertools
+import numpy as np
+
+from .grid import Grid
+
+
+def regrid_aligned(
+    data: np.array,
+    from_grid: Grid,
+    to_grid: Grid,
+) -> np.array:
+    """
+    Re-grids and subsets a dataset to a shape defined by to_grid. The source
+    data and the to_grid must share the same projection.
+    :param data: 2d gridded data
+    :param from_grid: Grid of the source data
+    :param to_grid: Target grid to reshape the data to
+    :return: 2d dataset of gridded cell values in the target grid
+    """
+    regridded_data = np.zeros(to_grid.shape, dtype=data.dtype)
+    target_cell_ratio = to_grid.cell_area / from_grid.cell_area
+    target_coords_x = to_grid.cell_coords_x()
+    target_coords_y = to_grid.cell_coords_y()
+
+    for iy, ix in itertools.product(range(regridded_data.shape[0]), range(regridded_data.shape[1])):
+        # find the cell indexes for each target cell in the source data grid
+        source_ix, source_iy, source_mask = from_grid.xy_to_cell_index(target_coords_x[ix], target_coords_y[iy])
+
+        if source_mask:
+            regridded_data[iy, ix] = data[source_iy, source_ix] * target_cell_ratio
+
+    return regridded_data

--- a/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
+++ b/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
@@ -26,6 +26,7 @@ import rioxarray as rxr
 import xarray as xr
 
 from openmethane_prior.config import PriorConfig, load_config_from_env, parse_cli_to_env
+from openmethane_prior.grid.regrid import regrid_aligned
 from openmethane_prior.outputs import (
     convert_to_timescale,
     add_ch4_total,
@@ -132,9 +133,11 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
         sector_gridded = remap_raster(sector_xr, config.domain_grid(), input_crs=lu_crs)
 
         # apply inventory mask before counting any land use
-        sector_gridded *= config.inventory_dataset()['inventory_mask']
+        inventory_mask_regridded = regrid_aligned(config.inventory_dataset()['inventory_mask'], config.inventory_grid(), config.domain_grid())
+        inventory_mask_regridded[inventory_mask_regridded != 0] = 1 # now pure land-oc mask
+        sector_gridded *= inventory_mask_regridded
 
-
+        # allocate inventory emissions proportional to each grid cell
         sector_gridded /=  sector_gridded.sum() # proportion of national emission in each grid square
         sector_gridded *= methaneInventoryBySector[sector]  # convert to national emissions in kg/gridcell
 

--- a/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
+++ b/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
@@ -24,6 +24,7 @@ import rioxarray as rxr
 import xarray as xr
 
 from openmethane_prior.config import PriorConfig, load_config_from_env, parse_cli_to_env
+from openmethane_prior.grid.regrid import regrid_aligned
 from openmethane_prior.outputs import (
     convert_to_timescale,
     add_ch4_total,
@@ -62,8 +63,10 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     om_ntlt = remap_raster(ntlt, config.domain_grid(), AREA_OR_POINT=ntlData.AREA_OR_POINT)
 
     # limit emissions to land points
-    om_ntlt *= config.inventory_dataset()["inventory_mask"]
-    
+    inventory_mask_regridded = regrid_aligned(config.inventory_dataset()['inventory_mask'], config.inventory_grid(), config.domain_grid())
+    inventory_mask_regridded[inventory_mask_regridded != 0] = 1 # now pure land-oc mask
+    om_ntlt *= inventory_mask_regridded
+
     # now collect total nightlights across inventory domain
     inventory_ntlt = remap_raster(ntlt, config.inventory_grid(), AREA_OR_POINT=ntlData.AREA_OR_POINT)
 
@@ -71,7 +74,8 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     inventory_ntlt *= config.inventory_dataset()['inventory_mask']
 
     # we want proportions of total for scaling emissions
-    om_ntlt_proportion = om_ntlt / inventory_ntlt.sum()
+    om_ntlt_proportion = om_ntlt / float(inventory_ntlt.sum())
+
     """ note that this is the correct scaling since remap_raster accumulates so
     that quotient is the proportion of total nightlights in that cell """
     sector_totals = pd.read_csv(

--- a/tests/unit/test_grid/test_regrid.py
+++ b/tests/unit/test_grid/test_regrid.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from openmethane_prior.grid.grid import Grid
+from openmethane_prior.grid.regrid import regrid_aligned
+
+
+def test_regrid_aligned_same_grid():
+    source_grid = Grid(
+        dimensions=(8, 10),
+        origin_xy=(-4, -5),
+        cell_size=(1, 2),
+    )
+    target_grid = Grid(
+        dimensions=(8, 10),
+        origin_xy=(-4, -5),
+        cell_size=(1, 2),
+    )
+    data = np.ones(source_grid.shape, dtype=np.float64)
+
+    result = regrid_aligned(data, source_grid, target_grid)
+
+    assert result.shape == target_grid.shape
+    assert result[0, 0] == 1.0
+    assert result.sum() == result.shape[0] * result.shape[1]
+
+def test_regrid_aligned_smaller_grid():
+    source_grid = Grid(
+        dimensions=(8, 10),
+        origin_xy=(-4, -5),
+        cell_size=(1, 2),
+    )
+    target_grid = Grid(
+        dimensions=(4, 5),
+        origin_xy=(-2, -3),
+        cell_size=(1, 1), # cells are half the area of source grid
+    )
+    data = np.ones(source_grid.shape, dtype=np.float64)
+
+    result = regrid_aligned(data, source_grid, target_grid)
+
+    assert result.shape == target_grid.shape
+    assert target_grid.cell_area / source_grid.cell_area == 0.5
+    np.testing.assert_almost_equal(result[0, 0], target_grid.cell_area / source_grid.cell_area)
+    assert result.sum() == result.shape[0] * result.shape[1] * 0.5


### PR DESCRIPTION


## Description

We want to apply the inventory mask to spatialised datasets before scaling, so we don't allocate emissions to areas outside of the inventory. However, to apply the mask we need to make it the same shape and cover the same area as the domain. The previous implementation only worked when the inventory and the domain were already on the same grid.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
