### PR TITLE
Read grid origin from domain bounds

### DIFF
--- a/changelog/112.improvement.md
+++ b/changelog/112.improvement.md
@@ -1,0 +1,1 @@
+Remove XORIG and YORIG from domain format, use x_bounds and y_bounds instead

--- a/scripts/create_prior_domain.py
+++ b/scripts/create_prior_domain.py
@@ -181,8 +181,6 @@ def create_domain_info(
             "DY": geom_xr.DY,
             "XCELL": mcip_cro_xr.XCELL,
             "YCELL": mcip_cro_xr.YCELL,
-            "XORIG": mcip_cro_xr.XORIG,
-            "YORIG": mcip_cro_xr.YORIG,
 
             # domain
             "domain_name": domain_name,

--- a/src/openmethane_prior/grid/create_grid.py
+++ b/src/openmethane_prior/grid/create_grid.py
@@ -32,9 +32,13 @@ def create_grid_from_domain(
     # find the domain variable containing the grid mapping
     grid_mapping = list_cf_grid_mappings(domain_ds)[0]
 
+    # the origin should be the coords of the llc boundary
+    origin_x = domain_ds["x_bounds"].min()
+    origin_y = domain_ds["y_bounds"].min()
+
     return Grid(
         dimensions=(domain_ds.sizes["x"], domain_ds.sizes["y"]),
-        origin_xy=(domain_ds.XORIG, domain_ds.YORIG),
+        origin_xy=(float(origin_x), float(origin_y)),
         cell_size=(domain_ds.XCELL, domain_ds.YCELL),
         proj_params=pyproj.CRS.from_cf(domain_ds[grid_mapping].attrs),
     )

--- a/tests/integration/test_domain.py
+++ b/tests/integration/test_domain.py
@@ -19,5 +19,3 @@ def test_domain_attributes(input_domain):
     assert input_domain.attrs['XCELL'] > 0
     assert type(input_domain.attrs["YCELL"]) == numpy.float64
     assert input_domain.attrs['YCELL'] > 0
-    assert type(input_domain.attrs["XORIG"]) == numpy.float64
-    assert type(input_domain.attrs["YORIG"]) == numpy.float64


### PR DESCRIPTION
## Description

Instead of writing domain origin to XORIG and YORIG attributes in the new domain format, we can just read the lower bounds from `x_bounds` and `y_bounds`. This means we don't have to write the same value to the file twice, which reduces the possibility of bugs if they contained different values.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
