### PR TITLE
fixing inventory normalisation for omAgLulucfWasteEmis

### DIFF
--- a/changelog/114.fix.md
+++ b/changelog/114.fix.md
@@ -1,0 +1,1 @@
+fixing national inventory normalisation

--- a/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
+++ b/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
@@ -141,7 +141,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
         inventory_gridded *= config.inventory_dataset()['inventory_mask']
 
         # allocate inventory emissions proportional to each grid cell
-        sector_gridded /=  inventory_gridded.sum() # proportion of national emission in each grid square
+        sector_gridded /=  inventory_gridded.sum().item() # proportion of national emission in each grid square
         sector_gridded *= methaneInventoryBySector[sector]  # convert to national emissions in kg/gridcell
 
         add_sector(

--- a/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
+++ b/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
@@ -135,9 +135,13 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
         # apply inventory mask before counting any land use
         inventory_mask_regridded = regrid_aligned(config.inventory_dataset()['inventory_mask'], from_grid=config.inventory_grid(), to_grid=config.domain_grid())
         sector_gridded *= inventory_mask_regridded
+        
+        inventory_gridded = remap_raster(sector_xr, config.inventory_grid(), input_crs=lu_crs)
+        # now mask to region of inventory
+        inventory_gridded *= config.inventory_dataset()['inventory_mask']
 
         # allocate inventory emissions proportional to each grid cell
-        sector_gridded /=  sector_gridded.sum() # proportion of national emission in each grid square
+        sector_gridded /=  inventory_gridded.sum() # proportion of national emission in each grid square
         sector_gridded *= methaneInventoryBySector[sector]  # convert to national emissions in kg/gridcell
 
         add_sector(

--- a/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
+++ b/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
@@ -73,7 +73,7 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     inventory_ntlt *= config.inventory_dataset()['inventory_mask']
 
     # we want proportions of total for scaling emissions
-    om_ntlt_proportion = om_ntlt / float(inventory_ntlt.sum())
+    om_ntlt_proportion = om_ntlt / inventory_ntlt.sum().item()
 
     """ note that this is the correct scaling since remap_raster accumulates so
     that quotient is the proportion of total nightlights in that cell """


### PR DESCRIPTION
## Description
there was an incorrect denominator for the national inventory total
for each land-use type
## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes