### PR TITLE
Simplify domain config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ INVENTORY_DOMAIN_FILE=https://openmethane.s3.amazonaws.com/domains/aust10km/v1/d
 #INVENTORY_DOMAIN_FILE=domain.aust10km.nc
 
 # Remote storage for input files
-PRIOR_REMOTE=https://prior.openmethane.org/
+PRIOR_REMOTE=https://openmethane.s3.amazonaws.com/prior/inputs/
 
 # Input files names
 # Use omDownloadInputs.py to fetch these files from the remote and place them in the inputs folder

--- a/.env.example
+++ b/.env.example
@@ -5,12 +5,12 @@ INTERMEDIATES=data/intermediates
 
 # Input domains
 # Use a published domain from the Open Methane data store (downloaded using omDownloadInputs.py)
-DOMAIN=https://openmethane.s3.amazonaws.com/domains/au-test/v1/domain.au-test.nc
-INVENTORY_DOMAIN=https://openmethane.s3.amazonaws.com/domains/aust10km/v1/domain.aust10km.nc
+DOMAIN_FILE=https://openmethane.s3.amazonaws.com/domains/au-test/v1/domain.au-test.nc
+INVENTORY_DOMAIN_FILE=https://openmethane.s3.amazonaws.com/domains/aust10km/v1/domain.aust10km.nc
 
 # Or use an absolute path or relative to the INPUTS folder
-#DOMAIN=domain.au-test.nc
-#INVENTORY_DOMAIN=domain.aust10km.nc
+#DOMAIN_FILE=domain.au-test.nc
+#INVENTORY_DOMAIN_FILE=domain.aust10km.nc
 
 # Remote storage for input files
 PRIOR_REMOTE=https://prior.openmethane.org/

--- a/.env.example
+++ b/.env.example
@@ -4,13 +4,13 @@ OUTPUTS=data/outputs
 INTERMEDIATES=data/intermediates
 
 # Input domains
-# Use a published domain from the OpenMethane website (downloaded using omDownloadInputs.py)
-DOMAIN_NAME=aust10km
-DOMAIN_VERSION=v1
-# Or use a predefined file in the inputs directory
-# DOMAIN=om-domain-info.nc
-INVENTORY_DOMAIN_NAME=aust10km
-INVENTORY_DOMAIN_VERSION=v1
+# Use a published domain from the Open Methane data store (downloaded using omDownloadInputs.py)
+DOMAIN=https://openmethane.s3.amazonaws.com/domains/au-test/v1/domain.au-test.nc
+INVENTORY_DOMAIN=https://openmethane.s3.amazonaws.com/domains/aust10km/v1/domain.aust10km.nc
+
+# Or use an absolute path or relative to the INPUTS folder
+#DOMAIN=domain.au-test.nc
+#INVENTORY_DOMAIN=domain.aust10km.nc
 
 # Remote storage for input files
 PRIOR_REMOTE=https://prior.openmethane.org/

--- a/changelog/118.breaking.1.md
+++ b/changelog/118.breaking.1.md
@@ -1,1 +1,1 @@
-Replace DOMAIN_NAME and DOMAIN_VERSION env variables with DOMAIN for specifying the input domain
+Replace DOMAIN_NAME and DOMAIN_VERSION env variables with DOMAIN_FILE for specifying the input domain

--- a/changelog/118.breaking.1.md
+++ b/changelog/118.breaking.1.md
@@ -1,0 +1,1 @@
+Replace DOMAIN_NAME and DOMAIN_VERSION env variables with DOMAIN for specifying the input domain

--- a/changelog/118.breaking.2.md
+++ b/changelog/118.breaking.2.md
@@ -1,0 +1,1 @@
+Replace INVENTORY_DOMAIN_NAME and INVENTORY_DOMAIN_VERSION env variables with INVENTORY_DOMAIN for specifying the inventory domain

--- a/changelog/118.breaking.2.md
+++ b/changelog/118.breaking.2.md
@@ -1,1 +1,1 @@
-Replace INVENTORY_DOMAIN_NAME and INVENTORY_DOMAIN_VERSION env variables with INVENTORY_DOMAIN for specifying the inventory domain
+Replace INVENTORY_DOMAIN_NAME and INVENTORY_DOMAIN_VERSION env variables with INVENTORY_DOMAIN_FILE for specifying the inventory domain

--- a/src/openmethane_prior/config.py
+++ b/src/openmethane_prior/config.py
@@ -201,8 +201,8 @@ def load_config_from_env(**overrides: PriorConfigOptions) -> PriorConfig:
         input_path=env.path("INPUTS", "data/inputs"),
         output_path=env.path("OUTPUTS", "data/outputs"),
         intermediates_path=env.path("INTERMEDIATES", "data/processed"),
-        domain_path=env.str("DOMAIN"),
-        inventory_domain_path=env.str("INVENTORY_DOMAIN"),
+        domain_path=env.str("DOMAIN_FILE"),
+        inventory_domain_path=env.str("INVENTORY_DOMAIN_FILE"),
         output_filename=env.str("OUTPUT_FILENAME", "prior-emissions.nc"),
         layer_inputs=LayerInputs(
             electricity_path=env.path("CH4_ELECTRICITY"),

--- a/src/openmethane_prior/inputs.py
+++ b/src/openmethane_prior/inputs.py
@@ -24,6 +24,7 @@ import requests
 
 from openmethane_prior.config import PriorConfig
 import openmethane_prior.logger as logger
+from openmethane_prior.utils import is_url
 
 logger = logger.get_logger(__name__)
 
@@ -49,7 +50,7 @@ def download_input_file(remote_url: str, url_fragment: str, save_path: pathlib.P
     -------
         True if the file was downloaded, False if a cached file was found
     """
-    url = urllib.parse.urljoin(remote_url, url_fragment)
+    url = url_fragment if is_url(url_fragment) else urllib.parse.urljoin(remote_url, url_fragment)
 
     if not os.path.exists(save_path):
         logger.info(f"Downloading {url_fragment} to {save_path} from {url}")
@@ -80,11 +81,11 @@ def check_input_files(config: PriorConfig):
 
     errors = []
 
-    if not config.input_domain_file.exists():
-        errors.append(f"\n- {config.input_domain_file.name} (domain info)")
+    if not config.domain_file.exists():
+        errors.append(f"\n- {config.domain_file} (domain info)")
 
     if not config.inventory_domain_file.exists():
-        errors.append(f"\n- {config.inventory_domain_file.name} (inventory domain)")
+        errors.append(f"\n- {config.inventory_domain_file} (inventory domain)")
 
     checks = (
         (config.layer_inputs.electricity_path, "electricity facilities"),

--- a/src/openmethane_prior/utils.py
+++ b/src/openmethane_prior/utils.py
@@ -30,6 +30,7 @@ import typing
 
 import numpy as np
 from numpy.typing import ArrayLike
+from urllib.parse import urlparse
 import xarray as xr
 
 T = typing.TypeVar("T", bound=ArrayLike | float)
@@ -198,3 +199,13 @@ def list_cf_grid_mappings(
         if "grid_mapping_name" in ds[var].attrs:
             grid_mappings.append(var)
     return grid_mappings
+
+
+def is_url(maybe_url: str) -> bool:
+    """
+    Returns true if the provided string is formatted like a valid URL.
+    :param maybe_url: string to check
+    :return:
+    """
+    parsed = urlparse(maybe_url)
+    return parsed.scheme != "" and parsed.netloc != ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import dotenv
 import pytest
 import xarray as xr
 
-from openmethane_prior.config import PriorConfig, PublishedInputDomain, load_config_from_env, PriorConfigOptions
+from openmethane_prior.config import PriorConfig, load_config_from_env, PriorConfigOptions
 from openmethane_prior.grid.create_grid import create_grid_from_mcip
 from openmethane_prior.grid.grid import Grid
 from scripts.omDownloadInputs import download_input_files
@@ -42,8 +42,8 @@ def config_params(start_date, end_date) -> PriorConfigOptions:
     return dict(
         start_date=start_date,
         end_date=end_date,
-        input_domain=PublishedInputDomain(name="au-test", version="v1"),
-        inventory_domain=PublishedInputDomain(name="aust10km", version="v1"),
+        domain_path="https://openmethane.s3.amazonaws.com/domains/au-test/v1/domain.au-test.nc",
+        inventory_domain_path="https://openmethane.s3.amazonaws.com/domains/aust10km/v1/domain.aust10km.nc",
     )
 
 
@@ -93,16 +93,14 @@ def fetch_published_domain(root_dir) -> list[pathlib.Path]:
     """
     config = load_config_from_env()
     published_domains = [
-        PublishedInputDomain(name="au-test", version="v1"), # domain
-        PublishedInputDomain(name="aust10km", version="v1"), # inventory
+        "https://openmethane.s3.amazonaws.com/domains/au-test/v1/domain.au-test.nc", # domain
+        "https://openmethane.s3.amazonaws.com/domains/aust10km/v1/domain.aust10km.nc", # inventory
     ]
-
-    fragments = [str(domain.path) for domain in published_domains]
 
     downloaded_files = download_input_files(
         remote=config.remote,
         download_path=root_dir / ".cache",
-        fragments=fragments,
+        fragments=published_domains,
     )
 
     return downloaded_files
@@ -196,7 +194,7 @@ def input_domain(config, root_dir, input_files) -> Generator[xr.Dataset, None, N
     -------
         The input domain as an xarray dataset
     """
-    assert config.input_domain_file.exists()
+    assert config.domain_file.exists()
 
     yield config.domain_dataset()
 

--- a/tests/integration/test_om_prior.py
+++ b/tests/integration/test_om_prior.py
@@ -42,8 +42,8 @@ def test_004_omDownloadInputs(root_dir, input_files, config):
         "EntericFermentation.nc",
         "termite_emissions_2010-2016.nc",
         "DLEM_totflux_CRU_diagnostic.nc",
-        "domains/au-test/v1/domain.au-test.nc",
-        "domains/aust10km/v1/domain.aust10km.nc",
+        "domain.au-test.nc",
+        "domain.aust10km.nc",
     ]
 
     assert sorted([str(fn.relative_to(config.input_path)) for fn in input_files]) == sorted(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import pytest
 
-from openmethane_prior.config import PriorConfig, LayerInputs, InputDomain, PublishedInputDomain
+from openmethane_prior.config import PriorConfig, LayerInputs
 
 
 # This fixture will allow each test to setup the required env variables and
@@ -40,8 +40,8 @@ def test_prior_config(tmp_path: pathlib.Path, mock_layer_inputs):
         input_path=tmp_path / "in",
         output_path=tmp_path / "out",
         intermediates_path=tmp_path / "inter",
-        input_domain=InputDomain("domain-input.nc"),
-        inventory_domain=InputDomain("domain-input.nc"),
+        domain_path="domain-input.nc",
+        inventory_domain_path="domain-input.nc",
         output_filename="out.nc",
         layer_inputs=mock_layer_inputs,
     )
@@ -50,32 +50,6 @@ def test_prior_config(tmp_path: pathlib.Path, mock_layer_inputs):
     assert test_config.as_output_file("test.nc") == tmp_path / "out" / "test.nc"
     assert test_config.as_intermediate_file("test.nc") == tmp_path / "inter" / "test.nc"
 
-    assert test_config.input_domain_file == tmp_path / "in" / "domain-input.nc"
+    assert test_config.domain_file == tmp_path / "in" / "domain-input.nc"
+    assert test_config.inventory_domain_file == tmp_path / "in" / "domain-input.nc"
     assert test_config.output_file == tmp_path / "out" / "out.nc"
-
-def test_input_domain():
-    test_defaults = InputDomain("default.nc")
-    assert str(test_defaults.path) == "default.nc"
-    assert test_defaults.name == "default"
-    assert test_defaults.version == "v1"
-    assert test_defaults.domain_index == 1
-    assert test_defaults.slug == "default"
-    assert str(test_defaults.path) == "default.nc"
-
-    test_domain = InputDomain(name="dname", version="v9.0.1", domain_index=33, slug="dslug", path="./file.nc")
-    assert test_domain.name == "dname"
-    assert test_domain.version == "v9.0.1"
-    assert test_domain.domain_index == 33
-    assert test_domain.slug == "dslug"
-    assert str(test_domain.path) == "file.nc"
-
-def test_published_input_domain():
-    test_domain = PublishedInputDomain(name="dname", version="v9.0.1", domain_index=3, slug="dslug")
-    assert test_domain.name == "dname"
-    assert test_domain.version == "v9.0.1"
-    assert test_domain.domain_index == 3
-    assert test_domain.slug == "dslug"
-    assert str(test_domain.path) == (
-        f"domains/dname/v9.0.1/"
-        f"domain.dname.nc"
-    )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,7 +6,7 @@ import sys
 import xarray as xr
 
 from openmethane_prior.utils import get_command, get_timestamped_command, time_bounds, bounds_from_cell_edges, \
-    mask_array_by_sequence
+    mask_array_by_sequence, is_url
 
 
 def test_get_command():
@@ -65,3 +65,22 @@ def test_mask_array_by_sequence():
         mask_array_by_sequence(test_array, (2, 4, 6)),
         [False, True, False, True, False, True],
     )
+
+
+def test_is_url():
+    cases = [
+        ("http://example.com", True),
+        ("https://example.com", True),
+        ("//example.com", False), # "//" scheme not supported
+        ("http", False),
+        ("http://", False),
+        ("https", False),
+        ("https://", False),
+        ("example.com", False),
+        ("", False),
+        ("http://example.com/path/to/file.txt", True),
+        ("https://example.com/path/to/file.txt", True),
+    ]
+
+    for test_url, expected in cases:
+        assert is_url(test_url) == expected


### PR DESCRIPTION
## Description

Simplify specifying the input domain and inventory domain using a single environment variable which supports a file path or URL.

This change makes `DOMAIN` and `INVENTORY_DOMAIN` the only way to specify the desire domain inputs, using `DOMAIN_NAME` and `DOMAIN_VERSION` are no longer supported.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
