### PR TITLE
Add ANZSIC sector codes

### DIFF
--- a/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
+++ b/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
@@ -43,20 +43,24 @@ logger = logger.get_logger(__name__)
 sector_meta_map = {
     "agriculture": SectorMeta(
         name="agriculture",
+        natural=False,
         cf_standard_name="agricultural_production",
     ),
     "lulucf": SectorMeta(
         name="lulucf",
+        natural=False,
         cf_standard_name="anthropogenic_land_use_change",
     ),
     "waste": SectorMeta(
         name="waste",
+        natural=False,
         cf_standard_name="waste_treatment_and_disposal",
     ),
 }
 
 livestock_sector_meta = SectorMeta(
     name="livestock",
+    natural=False,
     cf_standard_name="domesticated_livestock",
 )
 

--- a/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
+++ b/src/openmethane_prior/layers/omAgLulucfWasteEmis.py
@@ -33,18 +33,32 @@ from openmethane_prior.outputs import (
     add_sector,
     create_output_dataset, write_output_dataset,
 )
+from openmethane_prior.sector.sector import SectorMeta
 from openmethane_prior.utils import SECS_PER_YEAR, mask_array_by_sequence
 from openmethane_prior.raster import remap_raster
 import openmethane_prior.logger as logger
 
 logger = logger.get_logger(__name__)
 
-sectorEmissionStandardNames = {
-    "agriculture": "agricultural_production",
-    "lulucf": "anthropogenic_land_use_change",
-    "waste": "waste_treatment_and_disposal",
+sector_meta_map = {
+    "agriculture": SectorMeta(
+        name="agriculture",
+        cf_standard_name="agricultural_production",
+    ),
+    "lulucf": SectorMeta(
+        name="lulucf",
+        cf_standard_name="anthropogenic_land_use_change",
+    ),
+    "waste": SectorMeta(
+        name="waste",
+        cf_standard_name="waste_treatment_and_disposal",
+    ),
 }
 
+livestock_sector_meta = SectorMeta(
+    name="livestock",
+    cf_standard_name="domesticated_livestock",
+)
 
 def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR0912, PLR0915
     """
@@ -147,18 +161,16 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):  # noqa: PLR091
 
         add_sector(
             prior_ds=prior_ds,
-            sector_name=sector.lower(),
             sector_data=convert_to_timescale(sector_gridded, cell_area=domain_grid.cell_area),
-            sector_standard_name=sectorEmissionStandardNames[sector],
+            sector_meta=sector_meta_map[sector],
         )
 
     # convert the livestock data from per year to per second and write
     livestock_ch4_s = livestockCH4 / SECS_PER_YEAR
     add_sector(
         prior_ds=prior_ds,
-        sector_name="livestock",
         sector_data=livestock_ch4_s,
-        sector_standard_name="domesticated_livestock",
+        sector_meta=livestock_sector_meta,
     )
 
 

--- a/src/openmethane_prior/layers/omElectricityEmis.py
+++ b/src/openmethane_prior/layers/omElectricityEmis.py
@@ -37,6 +37,7 @@ logger = logger.get_logger(__name__)
 
 sector_meta = SectorMeta(
     name="electricity",
+    natural=False,
     cf_standard_name="energy_production_and_distribution",
 )
 

--- a/src/openmethane_prior/layers/omElectricityEmis.py
+++ b/src/openmethane_prior/layers/omElectricityEmis.py
@@ -31,8 +31,14 @@ from openmethane_prior.outputs import (
     write_output_dataset,
 )
 import openmethane_prior.logger as logger
+from openmethane_prior.sector.sector import SectorMeta
 
 logger = logger.get_logger(__name__)
+
+sector_meta = SectorMeta(
+    name="electricity",
+    cf_standard_name="energy_production_and_distribution",
+)
 
 def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     """
@@ -65,9 +71,8 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
 
     add_sector(
         prior_ds=prior_ds,
-        sector_name="electricity",
         sector_data=convert_to_timescale(methane, domain_grid.cell_area),
-        sector_standard_name="energy_production_and_distribution",
+        sector_meta=sector_meta,
     )
 
 

--- a/src/openmethane_prior/layers/omFugitiveEmis.py
+++ b/src/openmethane_prior/layers/omFugitiveEmis.py
@@ -37,6 +37,7 @@ logger = logger.get_logger(__name__)
 
 sector_meta = SectorMeta(
     name="fugitive",
+    natural=False,
     cf_standard_name="extraction_production_and_transport_of_fuel",
 )
 

--- a/src/openmethane_prior/layers/omFugitiveEmis.py
+++ b/src/openmethane_prior/layers/omFugitiveEmis.py
@@ -31,8 +31,14 @@ from openmethane_prior.outputs import (
     write_output_dataset,
 )
 import openmethane_prior.logger as logger
+from openmethane_prior.sector.sector import SectorMeta
 
 logger = logger.get_logger(__name__)
+
+sector_meta = SectorMeta(
+    name="fugitive",
+    cf_standard_name="extraction_production_and_transport_of_fuel",
+)
 
 def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
     """
@@ -78,9 +84,8 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset):
 
     add_sector(
         prior_ds=prior_ds,
-        sector_name="fugitive",
         sector_data=convert_to_timescale(methane, domain_grid.cell_area),
-        sector_standard_name="extraction_production_and_transport_of_fuel",
+        sector_meta=sector_meta,
     )
 
 

--- a/src/openmethane_prior/layers/omGFASEmis.py
+++ b/src/openmethane_prior/layers/omGFASEmis.py
@@ -23,7 +23,6 @@ See the project readme for more information about configuring
 the required credentials.
 """
 
-import argparse
 import bisect
 import datetime
 import itertools
@@ -38,6 +37,7 @@ from shapely import geometry
 
 from openmethane_prior.config import PriorConfig, load_config_from_env, parse_cli_to_env
 from openmethane_prior.outputs import add_ch4_total, add_sector, create_output_dataset, write_output_dataset
+from openmethane_prior.sector.sector import SectorMeta
 from openmethane_prior.utils import (
     area_of_rectangle_m2,
     load_zipped_pickle,
@@ -47,6 +47,11 @@ from openmethane_prior.utils import (
 import openmethane_prior.logger as logger
 
 logger = logger.get_logger(__name__)
+
+sector_meta = SectorMeta(
+    name="fire",
+    cf_standard_name="fires",
+)
 
 def download_GFAS(
     start_date: datetime.date,
@@ -226,9 +231,8 @@ def processEmissions(config: PriorConfig, prior_ds: xr.Dataset, forceUpdate: boo
     )
     add_sector(
         prior_ds=prior_ds,
-        sector_name="fire",
         sector_data=resultXr,
-        sector_standard_name="fires",
+        sector_meta=sector_meta,
     )
     return resultNd
 

--- a/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
+++ b/src/openmethane_prior/layers/omIndustrialStationaryTransportEmis.py
@@ -41,14 +41,17 @@ logger = logger.get_logger(__name__)
 sector_meta_map = {
     "industrial": SectorMeta(
         name="industrial",
+        natural=False,
         cf_standard_name="industrial_processes_and_combustion",
     ),
     "stationary": SectorMeta(
         name="stationary",
+        natural=False,
         cf_standard_name="industrial_energy_production",
     ),
     "transport": SectorMeta(
         name="transport",
+        natural=False,
         cf_standard_name="land_transport",
     ),
 }

--- a/src/openmethane_prior/layers/omTermiteEmis.py
+++ b/src/openmethane_prior/layers/omTermiteEmis.py
@@ -29,6 +29,7 @@ import xarray as xr
 
 from openmethane_prior.config import PriorConfig, load_config_from_env, parse_cli_to_env
 from openmethane_prior.outputs import add_ch4_total, add_sector, create_output_dataset, write_output_dataset
+from openmethane_prior.sector.sector import SectorMeta
 from openmethane_prior.utils import (
     SECS_PER_YEAR,
     area_of_rectangle_m2,
@@ -37,6 +38,10 @@ from openmethane_prior.utils import (
     save_zipped_pickle,
 )
 
+sector_meta = SectorMeta(
+    name="termite",
+    cf_standard_name="termites",
+)
 
 def processEmissions(  # noqa: PLR0915
     config: PriorConfig,
@@ -176,9 +181,8 @@ def processEmissions(  # noqa: PLR0915
 
     add_sector(
         prior_ds=prior_ds,
-        sector_name="termite",
         sector_data=resultNd,
-        sector_standard_name="termites",
+        sector_meta=sector_meta,
         # source dataset is a coarse grid, cells over water should be
         # excluded from results because there won't be termites there!
         apply_landmask=True,

--- a/src/openmethane_prior/layers/omWetlandEmis.py
+++ b/src/openmethane_prior/layers/omWetlandEmis.py
@@ -29,6 +29,7 @@ from shapely import geometry
 
 from openmethane_prior.config import PriorConfig, load_config_from_env, parse_cli_to_env
 from openmethane_prior.outputs import add_ch4_total, add_sector, create_output_dataset, write_output_dataset
+from openmethane_prior.sector.sector import SectorMeta
 from openmethane_prior.utils import (
     area_of_rectangle_m2,
     load_zipped_pickle,
@@ -37,6 +38,10 @@ from openmethane_prior.utils import (
     datetime64_to_datetime,
 )
 
+sector_meta = SectorMeta(
+    name="wetlands",
+    cf_standard_name="wetland_biological_processes",
+)
 
 def make_wetland_climatology(config: PriorConfig, forceUpdate: bool = False):  # noqa: PLR0915
     """
@@ -212,9 +217,8 @@ def processEmissions(
     )
     add_sector(
         prior_ds=prior_ds,
-        sector_name="wetlands",
         sector_data=result_xr,
-        sector_standard_name="wetland_biological_processes",
+        sector_meta=sector_meta,
         # source dataset is a coarse grid, and has emissions over ocean which
         # definitely shouldn't be classified as wetlands
         apply_landmask=True,

--- a/src/openmethane_prior/outputs.py
+++ b/src/openmethane_prior/outputs.py
@@ -195,6 +195,8 @@ def add_sector(
     }
     if sector_meta.cf_standard_name is not None:
         sector_data.attrs["standard_name"] += f"_due_to_emission_from_{sector_meta.cf_standard_name}"
+    if sector_meta.natural is not None:
+        sector_data.attrs["natural"] = sector_meta.natural
 
     _, aligned_sector_data = xr.align(prior_ds, sector_data, join="override")
 

--- a/src/openmethane_prior/sector/sector.py
+++ b/src/openmethane_prior/sector/sector.py
@@ -28,6 +28,8 @@ class SectorMeta:
     """A machine-friendly sector name that will be used in the name of the
     output variable, like `ch4_sector_{name}`"""
 
+    natural: bool = True
+
     cf_standard_name: str = None
     """The suffix of the CF Conventions `standard_name` attribute, which will
     be appended to `surface_upward_mass_flux_of_methane_due_to_emission_from_{cf_standard_name}`

--- a/src/openmethane_prior/sector/sector.py
+++ b/src/openmethane_prior/sector/sector.py
@@ -1,0 +1,37 @@
+#
+# Copyright 2025 The Superpower Institute Ltd.
+#
+# This file is part of Open Methane.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import attrs
+
+@attrs.frozen()
+class SectorMeta:
+    """
+    EmissionsSector describes a methane emission source or sources by name
+    and by various classification schemes.
+    """
+    name: str
+    """A machine-friendly sector name that will be used in the name of the
+    output variable, like `ch4_sector_{name}`"""
+
+    cf_standard_name: str = None
+    """The suffix of the CF Conventions `standard_name` attribute, which will
+    be appended to `surface_upward_mass_flux_of_methane_due_to_emission_from_{cf_standard_name}`
+    """
+
+    cf_long_name: str = None
+    """The CF Conventions `long_name` attribute, if needed."""

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -2,7 +2,9 @@ import numpy as np
 import xarray as xr
 import pytest
 
-from openmethane_prior.outputs import create_output_dataset, expand_sector_dims, write_output_dataset
+from openmethane_prior.outputs import create_output_dataset, expand_sector_dims, write_output_dataset, add_sector
+from openmethane_prior.sector.sector import SectorMeta
+
 
 def test_write_output_dataset(config, input_files):
     output_ds = create_output_dataset(config)
@@ -130,3 +132,61 @@ def test_expand_sector_dims_add_time_steps():
     assert list(expanded[1][0][1]) == [4, 5]
     assert list(expanded[2][0][0]) == [1, 2]
     assert list(expanded[2][0][1]) == [4, 5]
+
+def test_add_sector_defaults(config, input_files):
+    test_ds = create_output_dataset(config)
+
+    sector_meta = SectorMeta(
+        name="test_sector",
+    )
+    sector_shape = (test_ds.sizes["time"], 1, config.domain_grid().shape[0], config.domain_grid().shape[1])
+    sector_data = np.zeros(sector_shape)
+
+    assert sector_meta.name not in test_ds
+
+    add_sector(
+        prior_ds=test_ds,
+        sector_data=sector_data,
+        sector_meta=sector_meta,
+    )
+
+    sector_var = f"ch4_sector_{sector_meta.name}"
+
+    assert sector_var in test_ds
+    assert test_ds[sector_var].shape == sector_shape
+
+    assert test_ds[sector_var].attrs["standard_name"] == "surface_upward_mass_flux_of_methane"
+    assert test_ds[sector_var].attrs["long_name"] == "expected flux of methane caused by sector: test_sector"
+    assert test_ds[sector_var].attrs["units"] == "kg/m2/s"
+    assert test_ds[sector_var].attrs["grid_mapping"] == test_ds["land_mask"].attrs["grid_mapping"]
+
+
+def test_add_sector_meta(config, input_files):
+    test_ds = create_output_dataset(config)
+
+    sector_meta = SectorMeta(
+        name="test_sector",
+        cf_standard_name="standard_name_suffix",
+        cf_long_name="test long name",
+    )
+    sector_shape = (test_ds.sizes["time"], 1, config.domain_grid().shape[0], config.domain_grid().shape[1])
+    sector_data = np.zeros(sector_shape)
+
+    assert sector_meta.name not in test_ds
+
+    add_sector(
+        prior_ds=test_ds,
+        sector_data=sector_data,
+        sector_meta=sector_meta,
+    )
+
+    sector_var = f"ch4_sector_{sector_meta.name}"
+
+    assert sector_var in test_ds
+    assert test_ds[sector_var].shape == sector_shape
+
+    assert test_ds[sector_var].attrs["standard_name"] == \
+           "surface_upward_mass_flux_of_methane_due_to_emission_from_standard_name_suffix"
+    assert test_ds[sector_var].attrs["long_name"] == "test long name"
+    assert test_ds[sector_var].attrs["units"] == "kg/m2/s"
+    assert test_ds[sector_var].attrs["grid_mapping"] == test_ds["land_mask"].attrs["grid_mapping"]

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -157,6 +157,7 @@ def test_add_sector_defaults(config, input_files):
 
     assert test_ds[sector_var].attrs["standard_name"] == "surface_upward_mass_flux_of_methane"
     assert test_ds[sector_var].attrs["long_name"] == "expected flux of methane caused by sector: test_sector"
+    assert test_ds[sector_var].attrs["natural"] == True
     assert test_ds[sector_var].attrs["units"] == "kg/m2/s"
     assert test_ds[sector_var].attrs["grid_mapping"] == test_ds["land_mask"].attrs["grid_mapping"]
 
@@ -166,6 +167,7 @@ def test_add_sector_meta(config, input_files):
 
     sector_meta = SectorMeta(
         name="test_sector",
+        natural=False,
         cf_standard_name="standard_name_suffix",
         cf_long_name="test long name",
     )
@@ -188,5 +190,6 @@ def test_add_sector_meta(config, input_files):
     assert test_ds[sector_var].attrs["standard_name"] == \
            "surface_upward_mass_flux_of_methane_due_to_emission_from_standard_name_suffix"
     assert test_ds[sector_var].attrs["long_name"] == "test long name"
+    assert test_ds[sector_var].attrs["natural"] == False
     assert test_ds[sector_var].attrs["units"] == "kg/m2/s"
     assert test_ds[sector_var].attrs["grid_mapping"] == test_ds["land_mask"].attrs["grid_mapping"]


### PR DESCRIPTION
## Description

ANZSIC codes are a foundational reference that the Australian government uses to report on emissions. All sectoral emissions data released by the government uses the ANZSIC taxonomy to segregate different sectors.

This makes ANZSIC useful to the prior for places where we seek to use government data as an input (sectoral emissions from NGGI, or Safeguard Mechanism data), and it also serves to help us compare Open Methane emissions estimates back to government reporting.

Resolves #96.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
