### PR TITLE
Test using local docker image in GitHub Actions

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -34,16 +34,19 @@ jobs:
     # Builds and pushes the image
     # Tags the image with the PR that it is linked to
     steps:
+      # Setup repo and docker utils
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Login to Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract version from pyproject.toml
         id: version
@@ -86,38 +89,29 @@ jobs:
         run: |
           echo "REMOTE_ID=${{ env.REGISTRY }}/${{ env.IMAGE }}@${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
 
-  test-unit:
-    # Simple test suite to verify that the docker container works as expected
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: read
-      packages: read
-    container:
-      image: ghcr.io/openmethane/openmethane-prior@${{ needs.build.outputs.digest }}
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
-    steps:
-      - name: Check package version
+      # Run basic tests in the new container image
+      - name: Check built container package version
         if: startsWith(github.event.ref, 'refs/tags/v')
         run: |
           TAG_REF="${{ github.event.ref }}"
           TAG_VERSION=${TAG_REF#"refs/tags/"}
-          if [ "$OPENMETHANE_PRIOR_VERSION" != "$TAG_VERSION" ]; then
-            echo "OPENMETHANE_PRIOR_VERSION is $OPENMETHANE_PRIOR_VERSION; expected version is $TAG_VERSION"
-            exit 1
-          fi
-      - name: Run a quick test suite
+          docker run --rm -v ./tests:/opt/tests ${{ steps.remote-image-id.outputs.REMOTE_ID }} /bin/bash -c $'
+            if [ "$OPENMETHANE_PRIOR_VERSION" != "$TAG_VERSION" ]; then
+              echo "OPENMETHANE_PRIOR_VERSION is $OPENMETHANE_PRIOR_VERSION; expected version is $TAG_VERSION"
+              exit 1
+            fi
+          '
+      # Run a simple test to ensure basic functionality works
+      - name: Run a minimal test
         run: |
-          cd /opt/project
-          python -m pytest -r a -v tests/integration/test_domain.py
+          docker run --rm ${{ steps.remote-image-id.outputs.REMOTE_ID }} /bin/bash -c $'
+            python -m pytest -r a -v tests/integration/test_domain.py
+          '
 
   # Determine additional tags to apply to the image
   image-tags:
     runs-on: ubuntu-latest
-    needs: [ test-unit ]
+    needs: [ build ]
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,12 +24,18 @@ jobs:
       - name: Install the project
         run: |
           uv sync --locked --all-extras --dev
+      - name: Cache test data
+        uses: actions/cache@v4
+        with:
+          path: data/.cache
+          key: test-data-cache
       - name: Run tests
         run: |
           make test
         env:
           CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
           CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api
+          INPUT_CACHE: data/.cache
 
   check-build:
     runs-on: ubuntu-latest

--- a/changelog/162.trivial.md
+++ b/changelog/162.trivial.md
@@ -1,0 +1,1 @@
+Improve GitHub Actions test method and performance


### PR DESCRIPTION
## Description

This PR makes two minor improvements to GitHub Actions:

1. Test using local docker image

The previous implementation built and pushed a docker image to the GitHub Container Registry, then specified it as the container image for the next job, causing it to be pulled down again. This round-trip is unnecessary as there is already a local copy of the built image.

Furthermore, using our app container as a GitHub actions container is problematic for other reasons. Actions must run as root, which prevents us from using a non-root user in our application. Also, using actions in the container to set up things like caches introduces subtle changes in the test conditions that we should avoid.

2. Add an input cache

The prior uses a number of remote data sources, and all of these must be fetched and processed in the course of running the tests. Using an input cache will make tests run faster in GHA, at the expense of some fetch/parse methods not being invoked on every test run.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
