### PR TITLE
Fetch Safeguard Mechanism facility locations directly

### DIFF
--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -110,6 +110,41 @@ supporting dataset allows us to place those emissions in the correct grid cell
 or grid cells.
 
 
+## Safeguard Mechanism Facility Locations
+
+The Safeguard Mechanism Baselines and Emissions dataset includes facility-level
+methane emissions reported to the CER, but the locations of facilities are not
+made public. The
+[Safeguard Mechanism Facility Locations](https://docs.google.com/spreadsheets/d/1vET6DVXo3K9MeMYJj9sksSTmQjV3v9JmIPSlR6HS4NA)
+dataset was created by
+[The Superpower Institute](https://www.superpowerinstitute.com.au/) to detail
+the locations of sites and infrastructure related to each Safeguard facility so
+that their emissions can be allocated geographically.
+
+The dataset includes two parts:
+- external dataset references
+- direct locations
+
+Where possible, Safeguard facility locations have been identified in other
+public datasets, such as the National Pollutant Inventory or Climate TRACE.
+In these cases an external dataset reference is created by recording the
+Safeguard facility name alongside the `DataSource.name` of the external dataset
+and an identifier in the external dataset.
+
+For facility locations that can't be found in existing datasets, research by
+The Superpower Institute has used company reports, public datasets and
+satellite imagery to find and document sites and infrastructure related to
+each facility. These direct locations include a geographical coordinate, and
+operation dates for locations where the information is available. Each direct
+location record also includes references to public documents where the
+information was sourced.
+
+Both of these datasets have been made available via a public, read-only Google
+Sheet. The public sheet is backed by a private dataset maintained by The
+Superpower Institute, with data synced using
+[`IMPORTRANGE`](https://support.google.com/docs/answer/3093340).
+
+
 ## Land Use of Australia
 
 Some sectoral inventories are spatialised by identifying which Australian Land

--- a/src/openmethane_prior/data_sources/safeguard/data.py
+++ b/src/openmethane_prior/data_sources/safeguard/data.py
@@ -15,10 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import pandas as pd
+import pathlib
 
 from openmethane_prior.lib import ConfiguredDataSource, DataSource
+from openmethane_prior.lib.data_manager.fetchers import fetch_google_sheet_by_name_csv
+
 from .facility import create_facilities_from_safeguard_rows
 
 # NGER emissions numbers are reported in CO2 equivalent, so to calculate raw
@@ -72,18 +74,6 @@ def parse_csv_numeric(csv_value: str) -> float | None:
     return float(raw.replace(",", ""))
 
 
-def parse_location_csv(data_source: ConfiguredDataSource):
-    locations_rows_df = pd.read_csv(
-        filepath_or_buffer=data_source.asset_path,
-        header=0,
-        names=safeguard_locations_csv_columns,
-        usecols=["safeguard_facility_name", "data_source_name", "data_source_id"],
-    )
-
-    # filter out any rows with incomplete information
-    return locations_rows_df.dropna()
-
-
 def parse_safeguard_csv(data_source: ConfiguredDataSource):
     """Read the Safeguard Mechanism Baselines and Emissions Table CSV,
     returning only the data columns useful for methane estimation."""
@@ -101,17 +91,68 @@ def parse_safeguard_csv(data_source: ConfiguredDataSource):
         ch4_gwp=ar5_ch4_gwp, co2_gwp=ar5_co2_gwp,
     )
 
-
-safeguard_locations_data_source = DataSource(
-    name="safeguard-locations",
-    url="https://openmethane.s3.amazonaws.com/prior/inputs/facility-locations-v2.1.csv",
-    parse=parse_location_csv,
-)
-
-
+# Facility-level emissions reported under the Safeguard Mechanism.
+# Source: https://cer.gov.au/markets/reports-and-data/safeguard-data/2023-24-baselines-and-emissions-data
 safeguard_mechanism_data_source = DataSource(
     name="safeguard-mechanism",
     url="https://cer.gov.au/document/2023-24-baselines-and-emissions-table",
     file_path="2023-24-baselines-and-emissions-table.csv",
     parse=parse_safeguard_csv,
+)
+
+
+def fetch_location_csv(data_source: ConfiguredDataSource) -> pathlib.Path:
+    # Primary source of external locations
+    external_locations_df = fetch_google_sheet_by_name_csv(data_source.url, "External facility locations")
+
+    # Petroleum titles sheet has some extra details, but contains columns for
+    # Facility name, Data source, and Production license which can be converted
+    # into external location references.
+    petroleum_titles_df = fetch_google_sheet_by_name_csv(data_source.url, "Petroleum titles")
+    petroleum_locations_df = petroleum_titles_df \
+        .drop(columns=["Responsible emitter", "State"]) \
+        .rename(columns={
+            "Data source": "Supporting data source",
+            "Production license": "Supporting data id",
+        })
+
+    # Oil and gas sites, which are used as an independent DataSource in the
+    # oil_gas sector, already include the Facility name. Create a row for each
+    # facility in this with the facility name as both the name and the id.
+    oil_gas_sites = fetch_google_sheet_by_name_csv(data_source.url, "Oil and gas sites")
+    oil_gas_facilities = oil_gas_sites["Facility name"].unique()
+    oil_gas_locations_df = pd.DataFrame({
+        "Facility name": oil_gas_facilities,
+        "Supporting data id": oil_gas_facilities,
+        "Supporting data source": "oil-gas-sites",
+    })
+
+    # Combine the sources of facility locations and write them to a CSV file
+    df = pd.concat([external_locations_df, oil_gas_locations_df, petroleum_locations_df])
+    df.to_csv(data_source.asset_path, index=False)
+    return data_source.asset_path
+
+
+def parse_location_csv(data_source: ConfiguredDataSource):
+    locations_rows_df = pd.read_csv(
+        filepath_or_buffer=data_source.asset_path,
+        header=0,
+        names=safeguard_locations_csv_columns,
+        usecols=["safeguard_facility_name", "data_source_name", "data_source_id"],
+    )
+
+    # filter out any rows with incomplete information
+    return locations_rows_df.dropna()
+
+
+# Locations of Safeguard Mechanism facilities which are found in other data
+# sources are recorded in The Superpower Institute's Safeguard Mechanism
+# Facility Locations dataset.
+# Source: https://docs.google.com/spreadsheets/d/1vET6DVXo3K9MeMYJj9sksSTmQjV3v9JmIPSlR6HS4NA
+safeguard_locations_data_source = DataSource(
+    name="safeguard-locations",
+    file_path="safeguard-facility-locations.csv",
+    url="https://docs.google.com/spreadsheets/d/1vET6DVXo3K9MeMYJj9sksSTmQjV3v9JmIPSlR6HS4NA",
+    fetch=fetch_location_csv,
+    parse=parse_location_csv,
 )

--- a/src/openmethane_prior/lib/data_manager/fetchers.py
+++ b/src/openmethane_prior/lib/data_manager/fetchers.py
@@ -1,0 +1,70 @@
+#
+# Copyright 2025 The Superpower Institute Ltd.
+#
+# This file is part of Open Methane.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pandas as pd
+import pathlib
+import urllib.parse
+
+from .source import ConfiguredDataSource
+
+
+def fetch_google_sheet_by_name_csv(
+    sheet_id_or_url: str,
+    sheet_name: str,
+) -> pd.DataFrame:
+    """Fetch a single sheet from a publicly viewable Google Sheet and return
+    the contents as a pandas DataFrame."""
+    if "://docs.google.com" in sheet_id_or_url:
+        # if a url is provided, extract the sheet_id
+        sheet_url = urllib.parse.urlparse(sheet_id_or_url)
+        sheet_id = sheet_url.path.rpartition('/')[-1]
+    else:
+        sheet_id = sheet_id_or_url
+
+    # make the sheet name url-safe
+    sheet_name_param = urllib.parse.quote(sheet_name)
+
+    # Google Sheets provides a CSV endpoint for downloading
+    url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/gviz/tq?tqx=out:csv&sheet={sheet_name_param}"
+    df = pd.read_csv(url)
+
+    # remove empty columns with no name or data
+    for column_name in df.columns:
+        if "Unnamed: " in column_name and df[column_name].isnull().all():
+            del df[column_name]
+
+    return df
+
+
+def fetch_google_sheet_csv(sheet_name: str):
+    """Return a DataSource fetch-compatible method for a DataSource where a
+    Google Sheet is specified by the url parameter and only a single sheet
+    should be fetched.
+
+    Usage:
+        DataSource(
+            url="https://docs.google.com/spreadsheets/d/EXAMPLE_SHEET_ID",
+            fetch=fetch_google_sheet_csv("Sheet name"),
+            ...
+        )
+    """
+    def _data_source_fetch(data_source: ConfiguredDataSource) -> pathlib.Path:
+        df = fetch_google_sheet_by_name_csv(data_source.url, sheet_name)
+        df.to_csv(data_source.asset_path, index=False)
+        return data_source.asset_path
+
+    return _data_source_fetch

--- a/src/openmethane_prior/sectors/oil_gas/data/oil_gas_sites.py
+++ b/src/openmethane_prior/sectors/oil_gas/data/oil_gas_sites.py
@@ -18,46 +18,10 @@
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-import pathlib
-import urllib.parse
 
 from openmethane_prior.lib import DataSource
+from openmethane_prior.lib.data_manager.fetchers import fetch_google_sheet_csv
 from openmethane_prior.lib.data_manager.source import ConfiguredDataSource
-
-
-def fetch_google_sheet_csv(
-    sheet_id_or_url: str,
-    sheet_name: str,
-) -> pd.DataFrame:
-    """Fetch a single sheet from a publicly viewable Google Sheet and return
-    the contents as a pandas DataFrame."""
-    if "://docs.google.com" in sheet_id_or_url:
-        # if a url is provided, extract the sheet_id
-        sheet_url = urllib.parse.urlparse(sheet_id_or_url)
-        sheet_id = sheet_url.path.rpartition('/')[-1]
-    else:
-        sheet_id = sheet_id_or_url
-
-    # remove strings from the sheet name so it is url-safe
-    sheet_name = sheet_name.replace(" ", "")
-
-    # Google Sheets provides a CSV endpoint for downloading
-    url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/gviz/tq?tqx=out:csv&amp;sheet={sheet_name}"
-    df = pd.read_csv(url)
-
-    # remove empty columns with no name or data
-    for column_name in df.columns:
-        if "Unnamed: " in column_name and df[column_name].isnull().all():
-            del df[column_name]
-
-    return df
-
-
-def fetch_oil_gas_sites_csv(data_source: ConfiguredDataSource) -> pathlib.Path:
-    """Fetch the oil and gas sites from Google Sheets and save as a CSV."""
-    df = fetch_google_sheet_csv(data_source.url, "Oil and gas sites")
-    df.to_csv(data_source.asset_path)
-    return data_source.asset_path
 
 
 def parse_oil_gas_sites_csv(data_source: ConfiguredDataSource) -> gpd.GeoDataFrame:
@@ -95,6 +59,6 @@ oil_gas_sites_data_source = DataSource(
     name="oil-gas-sites",
     file_path="oil-gas-sites.csv",
     url="https://docs.google.com/spreadsheets/d/1vET6DVXo3K9MeMYJj9sksSTmQjV3v9JmIPSlR6HS4NA",
-    fetch=fetch_oil_gas_sites_csv,
+    fetch=fetch_google_sheet_csv("Oil and gas sites"),
     parse=parse_oil_gas_sites_csv,
 )

--- a/src/openmethane_prior/sectors/oil_gas/data/oil_gas_sites.py
+++ b/src/openmethane_prior/sectors/oil_gas/data/oil_gas_sites.py
@@ -18,9 +18,46 @@
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import pathlib
+import urllib.parse
 
 from openmethane_prior.lib import DataSource
 from openmethane_prior.lib.data_manager.source import ConfiguredDataSource
+
+
+def fetch_google_sheet_csv(
+    sheet_id_or_url: str,
+    sheet_name: str,
+) -> pd.DataFrame:
+    """Fetch a single sheet from a publicly viewable Google Sheet and return
+    the contents as a pandas DataFrame."""
+    if "://docs.google.com" in sheet_id_or_url:
+        # if a url is provided, extract the sheet_id
+        sheet_url = urllib.parse.urlparse(sheet_id_or_url)
+        sheet_id = sheet_url.path.rpartition('/')[-1]
+    else:
+        sheet_id = sheet_id_or_url
+
+    # remove strings from the sheet name so it is url-safe
+    sheet_name = sheet_name.replace(" ", "")
+
+    # Google Sheets provides a CSV endpoint for downloading
+    url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/gviz/tq?tqx=out:csv&amp;sheet={sheet_name}"
+    df = pd.read_csv(url)
+
+    # remove empty columns with no name or data
+    for column_name in df.columns:
+        if "Unnamed: " in column_name and df[column_name].isnull().all():
+            del df[column_name]
+
+    return df
+
+
+def fetch_oil_gas_sites_csv(data_source: ConfiguredDataSource) -> pathlib.Path:
+    """Fetch the oil and gas sites from Google Sheets and save as a CSV."""
+    df = fetch_google_sheet_csv(data_source.url, "Oil and gas sites")
+    df.to_csv(data_source.asset_path)
+    return data_source.asset_path
 
 
 def parse_oil_gas_sites_csv(data_source: ConfiguredDataSource) -> gpd.GeoDataFrame:
@@ -50,11 +87,14 @@ def parse_oil_gas_sites_csv(data_source: ConfiguredDataSource) -> gpd.GeoDataFra
     return gdf
 
 
-# Processing facilities in the oil and gas industry in Australia. This dataset
-# was manually created from research conducted by The Superpower Institute to
-# identify locations of processing sites linked to Safeguard Mechanism facilities.
+# Processing facilities in the oil and gas industry in Australia. This dataset,
+# created by The Superpower Institute, identifies locations of oil and gas
+# sites linked to Safeguard Mechanism facilities.
+# Source: https://docs.google.com/spreadsheets/d/1vET6DVXo3K9MeMYJj9sksSTmQjV3v9JmIPSlR6HS4NA
 oil_gas_sites_data_source = DataSource(
     name="oil-gas-sites",
-    url="https://openmethane.s3.amazonaws.com/prior/inputs/oil-gas-sites-v0.4.csv",
+    file_path="oil-gas-sites.csv",
+    url="https://docs.google.com/spreadsheets/d/1vET6DVXo3K9MeMYJj9sksSTmQjV3v9JmIPSlR6HS4NA",
+    fetch=fetch_oil_gas_sites_csv,
     parse=parse_oil_gas_sites_csv,
 )


### PR DESCRIPTION
## Description

The source of the Safeguard Mechanism facility data is research conducted by The Superpower Institute, which is kept in a Google Sheet. When updates are made to Safeguard Mechanism oil and gas sites, petroleum titles or external data references in this Google Sheet, these data sources must be manually recombined into the `facility-locations-vXYZ.csv` and uploaded to the Public Data Store.

This PR removes much of the manual labour involved by sourcing the data directly from Google Sheets, and combining the three types of location data programatically. The results are then saved in a `safeguard-facility-locations.csv` in the `inputs` folder, so that the source data for the run can be persisted even if the source data changes.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
