### PR TITLE
Fix build version check to pass required `TAG_VERSION` env var

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -95,7 +95,7 @@ jobs:
         run: |
           TAG_REF="${{ github.event.ref }}"
           TAG_VERSION=${TAG_REF#"refs/tags/"}
-          docker run --rm -v ./tests:/opt/tests ${{ steps.remote-image-id.outputs.REMOTE_ID }} /bin/bash -c $'
+          docker run --rm -e TAG_VERSION=$TAG_VERSION ${{ steps.remote-image-id.outputs.REMOTE_ID }} /bin/bash -c $'
             if [ "$OPENMETHANE_PRIOR_VERSION" != "$TAG_VERSION" ]; then
               echo "OPENMETHANE_PRIOR_VERSION is $OPENMETHANE_PRIOR_VERSION; expected version is $TAG_VERSION"
               exit 1

--- a/changelog/177.fix.md
+++ b/changelog/177.fix.md
@@ -1,0 +1,1 @@
+Fix GitHub Actions build version check to include TAG_VERSION env var


### PR DESCRIPTION
## Description

The container version check uses a TAG_VERSION env var which is no longer available now that the version check is run using `docker run`. This change passes the necessary env var to `docker run` via the `-e` flag.

This wasn't caught in any PR builds because this step only runs on version release builds.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
