### PR TITLE
Update Safeguard CSV parsing config to reflect new format

### DIFF
--- a/changelog/189.fix.md
+++ b/changelog/189.fix.md
@@ -1,0 +1,1 @@
+Update Safeguard baselines CSV parsing to reflect updated format

--- a/src/openmethane_prior/data_sources/safeguard/data.py
+++ b/src/openmethane_prior/data_sources/safeguard/data.py
@@ -42,6 +42,7 @@ safeguard_mechanism_csv_columns = [
     "accus_deemed_surrendered", # ACCUs deemed surrendered
     "accus_surrendered", # ACCUs surrendered
     "smcs_surrendered", # SMCs surrendered
+    "units_relinquished", # Units relinquished
     "net_emissions", # Net emissions number
     "net_position", # Net position number
     "smcs_issued", # SMCs Issued
@@ -86,7 +87,6 @@ def parse_safeguard_csv(data_source: ConfiguredDataSource):
     returning only the data columns useful for methane estimation."""
     safeguard_rows_df = pd.read_csv(
         filepath_or_buffer=data_source.asset_path,
-        encoding="cp1252", # CER distributes the CSV in windows-1252 encoding
         header=0,
         names=safeguard_mechanism_csv_columns,
         usecols=["facility_name", "state", "anzsic", "co2e_ch4"],  # from safeguard_mechanism_csv_columns


### PR DESCRIPTION
## Description

The CER has published an updated Safeguard baselines and emissions file for FY 2023-24. The updated file is published in UTF-8 and adds a "Units relinquished" column.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
