### PR TITLE
Store static data in a separate path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DOMAIN_FILE=https://openmethane.s3.amazonaws.com/domains/au-test/v1/domain.au-te
 #INPUTS=data/inputs
 #OUTPUTS=data/outputs
 #INTERMEDIATES=data/intermediates
+#STATIC_INPUTS=data/static
 
 # Contents of this folder will be copied into the INPUTS folder before each
 # run, and INPUTS will be cached here after each run. Can reduce refetches of

--- a/.gitignore
+++ b/.gitignore
@@ -213,9 +213,7 @@ pyrightconfig.json
 
 # Custom ignores
 
-outputs
-inputs
-intermediates
-processed
+# Default data paths
+data/*
 
 !src/openmethane_prior/lib

--- a/changelog/193.feature.md
+++ b/changelog/193.feature.md
@@ -1,0 +1,1 @@
+Allow storing static data in a separate path

--- a/scripts/omPrior.py
+++ b/scripts/omPrior.py
@@ -54,3 +54,7 @@ if __name__ == "__main__":
     # write the output to file
     config.output_file.parent.mkdir(parents=True, exist_ok=True)
     prior_ds.to_netcdf(config.output_file)
+
+    # write config into output folder on success
+    with open(config.output_path / "config.yaml", "w") as config_out:
+        config_out.write(config.to_yaml())

--- a/src/openmethane_prior/lib/config.py
+++ b/src/openmethane_prior/lib/config.py
@@ -51,6 +51,9 @@ class PriorConfig:
     """Filename to write the prior output to as a NetCDFv4 file in
     `output_path`"""
 
+    static_path: pathlib.Path = None
+    """Filesystem path where static input files exist or should be fetched to."""
+
     input_cache: pathlib.Path = None
     """If provided, a local path where remote inputs can be cached."""
 
@@ -58,41 +61,54 @@ class PriorConfig:
     # by attrs has run.
     # @see: https://www.attrs.org/en/stable/init.html
     def __attrs_post_init__(self):
+        # Note: __setattr__ is used due to frozen class attributes being read-only
+
+        # if no static_path is provided, use the input_path
+        if self.static_path is None:
+            object.__setattr__(self, "static_path", self.input_path)
         # if no end_date is provided, estimate a single day specified by start_date
         if self.end_date is None:
-            # can't set attributes on frozen class
             object.__setattr__(self, "end_date", self.start_date)
-
-
-    def as_input_file(self, name: str | pathlib.Path) -> pathlib.Path:
-        """Return the full path to an input file"""
-        return self.input_path / name
 
     def as_intermediate_file(self, name: str | pathlib.Path) -> pathlib.Path:
         """Return the full path to an intermediate file"""
         return self.intermediates_path / name
-
-    def as_output_file(self, name: str | pathlib.Path) -> pathlib.Path:
-        """Return the full path to an output file"""
-        return self.output_path / name
 
     def prepare_paths(self):
         """Create any configured directory paths that don't already exist."""
         self.input_path.mkdir(parents=True, exist_ok=True)
         self.intermediates_path.mkdir(parents=True, exist_ok=True)
         self.output_path.mkdir(parents=True, exist_ok=True)
+        self.static_path.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def _cache_paths(self):
+        if self.input_cache is None:
+            return None
+        # TODO add control to disable caching dynamic data
+        cache_paths = {
+            self.input_path: self.input_cache / "inputs",
+            self.intermediates_path: self.input_cache / "intermediates",
+        }
+        if self.static_path != self.input_path:
+            cache_paths[self.static_path] = self.input_cache / "static"
+        return cache_paths
 
     def load_cached_inputs(self):
-        """Copy the contents of the input cache into the input folder."""
-        if self.input_cache is not None and self.input_cache.exists():
-            shutil.copytree(src=self.input_cache, dst=self.input_path, dirs_exist_ok=True)
+        """Copy the contents of the cache into the corresponding data paths."""
+        if self.input_cache is None or self._cache_paths is None:
+            return
+        for i, (data_path, cache_path) in enumerate(self._cache_paths.items()):
+            if cache_path.exists():
+                shutil.copytree(src=cache_path, dst=data_path, dirs_exist_ok=True)
 
     def cache_inputs(self):
-        """Copy everything in the inputs folder back into the cache, so that
-        any new inputs fetched during this run will be cached."""
-        if self.input_cache is not None:
-            self.input_cache.mkdir(parents=True, exist_ok=True)
-            shutil.copytree(src=self.input_path, dst=self.input_cache, dirs_exist_ok=True)
+        """Cache inputs and intermediates for re-use on subsequent runs."""
+        if self.input_cache is None or self._cache_paths is None:
+            return
+        for i, (data_path, cache_path) in enumerate(self._cache_paths.items()):
+            if data_path.exists():
+                shutil.copytree(src=data_path, dst=cache_path, dirs_exist_ok=True)
 
     @cache
     def domain(self) -> Domain:
@@ -109,7 +125,7 @@ class PriorConfig:
     @property
     def output_file(self):
         """Get the filename of the output domain"""
-        return self.as_output_file(self.output_filename)
+        return self.output_path / self.output_filename
 
     @classmethod
     def from_env(cls) -> Self:
@@ -138,6 +154,7 @@ class PriorConfig:
             input_path=env.path("INPUTS", None),
             output_path=env.path("OUTPUTS", None),
             intermediates_path=env.path("INTERMEDIATES", None),
+            static_path=env.path("STATIC_INPUTS", None),
             input_cache=env.path("INPUT_CACHE", None),
             output_filename=env.str("OUTPUT_FILENAME", None),
             sectors=sectors if len(sectors) > 0 else None,

--- a/src/openmethane_prior/lib/config.py
+++ b/src/openmethane_prior/lib/config.py
@@ -1,4 +1,6 @@
 import argparse
+
+import attrs
 from attrs import field, frozen
 from attrs.converters import default_if_none
 import datetime
@@ -9,6 +11,7 @@ import pathlib
 import shutil
 from typing import Self
 import urllib.request
+import yaml
 
 from .grid.domain import Domain
 
@@ -109,6 +112,14 @@ class PriorConfig:
         for i, (data_path, cache_path) in enumerate(self._cache_paths.items()):
             if data_path.exists():
                 shutil.copytree(src=data_path, dst=cache_path, dirs_exist_ok=True)
+
+    def to_yaml(self):
+        attrs_dict = attrs.asdict(self)
+        for i, (key, value) in enumerate(attrs_dict.items()):
+            # cast Path objects to string for more terse output
+            if isinstance(value, pathlib.Path):
+                attrs_dict[key] = str(value)
+        return yaml.dump(attrs_dict)
 
     @cache
     def domain(self) -> Domain:

--- a/src/openmethane_prior/lib/create_prior.py
+++ b/src/openmethane_prior/lib/create_prior.py
@@ -40,7 +40,11 @@ def create_prior(config: PriorConfig, sectors: list[PriorSector]):
     # if no cache is configured, this is a no-op
     config.load_cached_inputs()
 
-    data_manager = DataManager(data_path=config.input_path, prior_config=config)
+    data_manager = DataManager(
+        data_path=config.input_path,
+        static_path=config.static_path,
+        prior_config=config,
+    )
 
     # Initialise the output dataset based on the domain provided in config
     prior_ds = create_output_dataset(config)

--- a/src/openmethane_prior/lib/create_prior.py
+++ b/src/openmethane_prior/lib/create_prior.py
@@ -40,11 +40,7 @@ def create_prior(config: PriorConfig, sectors: list[PriorSector]):
     # if no cache is configured, this is a no-op
     config.load_cached_inputs()
 
-    data_manager = DataManager(
-        data_path=config.input_path,
-        static_path=config.static_path,
-        prior_config=config,
-    )
+    data_manager = DataManager.from_config(config)
 
     # Initialise the output dataset based on the domain provided in config
     prior_ds = create_output_dataset(config)

--- a/src/openmethane_prior/lib/data_manager/manager.py
+++ b/src/openmethane_prior/lib/data_manager/manager.py
@@ -36,6 +36,9 @@ class DataManager:
     prior_config: PriorConfig
     """Configuration for the current run of the prior"""
 
+    static_path: pathlib.Path = None
+    """Folder on the filesystem where fetched data will be stored"""
+
     fetch_only: bool = False
     """If True, assets will only be fetched and not parsed"""
 
@@ -44,6 +47,12 @@ class DataManager:
 
     data_assets: dict[str, DataAsset] = attrs.Factory(dict)
     """All data assets that have been fetched and processed"""
+
+    # @see: https://www.attrs.org/en/stable/init.html
+    def __attrs_post_init__(self):
+        # if no static_path is provided, use the data_path
+        if self.static_path is None:
+            self.static_path = self.data_path
 
     def add_source(self, source: DataSource) -> ConfiguredDataSource:
         """Add a data source to this data manager"""
@@ -65,6 +74,7 @@ class DataManager:
             data_source=source,
             prior_config=self.prior_config,
             data_path=self.data_path,
+            static_path=self.static_path,
             data_assets=dependency_assets,
         )
         return self.data_sources[source.name]

--- a/src/openmethane_prior/lib/data_manager/manager.py
+++ b/src/openmethane_prior/lib/data_manager/manager.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import Self
+
 import attrs
 import pathlib
 
@@ -126,3 +128,13 @@ class DataManager:
             self.data_assets[source.name] = asset
 
         return asset
+
+
+    @classmethod
+    def from_config(cls, config: PriorConfig) -> Self:
+        """Create DataManager instance based on settings in PriorConfig."""
+        return cls(
+            data_path=config.input_path,
+            static_path=config.static_path,
+            prior_config=config,
+        )

--- a/src/openmethane_prior/lib/data_manager/source.py
+++ b/src/openmethane_prior/lib/data_manager/source.py
@@ -67,6 +67,10 @@ class DataSource:
     name: str = attrs.field()
     """Unique, machine-friendly name that can be used to identify this data"""
 
+    dynamic: bool = False
+    """Set to True if the data source must be fetched on every run, or if the 
+    fetched data is dependent on prior parameters such as dates or domain."""
+
     url: str = attrs.field(default=None)
     """Publicly accessible URL where this data can be downloaded"""
 
@@ -164,17 +168,23 @@ class ConfiguredDataSource:
 
 
 def configure_data_source(
-        data_source: DataSource,
-        prior_config: PriorConfig,
-        data_path: pathlib.Path,
-        data_assets: list[DataAsset] = None,
+    data_source: DataSource,
+    prior_config: PriorConfig,
+    data_path: pathlib.Path,
+    static_path: pathlib.Path = None,
+    data_assets: list[DataAsset] = None,
 ):
     """Create a ConfiguredDataSource from a DataSource and a PriorConfig"""
     file_path = data_source.file_path
     if callable(file_path):
         file_path = file_path(data_source, prior_config)
 
-    asset_path = file_path if os.path.isabs(file_path) else data_path / file_path
+    # by default, dynamic data is stored in the configured data_path, while
+    # non-dynamic data is stored in the static_path.
+    data_storage_path = data_path
+    if not data_source.dynamic and static_path is not None:
+        data_storage_path = static_path
+    asset_path = file_path if os.path.isabs(file_path) else data_storage_path / file_path
 
     return ConfiguredDataSource(
         name=data_source.name,
@@ -183,6 +193,6 @@ def configure_data_source(
         source_fetch=data_source.fetch,
         source_parse=data_source.parse,
         prior_config=prior_config,
-        data_path=data_path,
+        data_path=data_storage_path,
         data_assets=data_assets if data_assets is not None else [],
     )

--- a/src/openmethane_prior/lib/verification.py
+++ b/src/openmethane_prior/lib/verification.py
@@ -44,7 +44,11 @@ MAX_ABS_DIFF = 0.1
 
 def verify_emis(sectors: list[PriorSector], config: PriorConfig, prior_ds: xr.Dataset, atol: float = MAX_ABS_DIFF):
     """Check output sector emissions to make sure they tally up to the input emissions"""
-    data_manager = DataManager(data_path=config.input_path, prior_config=config)
+    data_manager = DataManager(
+        data_path=config.input_path,
+        static_path=config.static_path,
+        prior_config=config,
+    )
     domain = config.domain()
     inventory_domain = data_manager.get_asset(inventory_domain_data_source).data
 

--- a/src/openmethane_prior/lib/verification.py
+++ b/src/openmethane_prior/lib/verification.py
@@ -44,11 +44,7 @@ MAX_ABS_DIFF = 0.1
 
 def verify_emis(sectors: list[PriorSector], config: PriorConfig, prior_ds: xr.Dataset, atol: float = MAX_ABS_DIFF):
     """Check output sector emissions to make sure they tally up to the input emissions"""
-    data_manager = DataManager(
-        data_path=config.input_path,
-        static_path=config.static_path,
-        prior_config=config,
-    )
+    data_manager = DataManager.from_config(config)
     domain = config.domain()
     inventory_domain = data_manager.get_asset(inventory_domain_data_source).data
 

--- a/src/openmethane_prior/sectors/fire/data_gfas.py
+++ b/src/openmethane_prior/sectors/fire/data_gfas.py
@@ -55,4 +55,5 @@ gfas_data_source = DataSource(
     name="gfas",
     file_path=gfas_file_name,
     fetch=gfas_fetch,
+    dynamic=True,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ def input_files(config):
 
 @pytest.fixture()
 def data_manager(config) -> DataManager:
-    return DataManager(data_path=config.input_path, prior_config=config)
+    return DataManager.from_config(config)
 
 
 @pytest.fixture()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -37,6 +37,7 @@ def test_prior_config_defaults(start_date, end_date):
     assert test_config.output_path == pathlib.Path("data/outputs")
     assert test_config.intermediates_path == pathlib.Path("data/intermediates")
     assert test_config.output_filename == "prior-emissions.nc"
+    assert test_config.static_path == test_config.input_path
     assert test_config.input_cache is None
 
     test_config_none = PriorConfig(
@@ -53,6 +54,7 @@ def test_prior_config_defaults(start_date, end_date):
     assert test_config_none.input_path == pathlib.Path("data/inputs")
     assert test_config_none.output_path == pathlib.Path("data/outputs")
     assert test_config_none.intermediates_path == pathlib.Path("data/intermediates")
+    assert test_config_none.static_path == test_config_none.input_path
     assert test_config_none.output_filename == "prior-emissions.nc"
 
 
@@ -64,14 +66,38 @@ def test_prior_config_full(tmp_path: pathlib.Path, start_date, end_date):
         input_path=tmp_path / "in",
         output_path=tmp_path / "out",
         intermediates_path=tmp_path / "inter",
+        static_path=tmp_path / "static",
         output_filename="out.nc",
     )
 
-    assert test_config.as_input_file("test.nc") == tmp_path / "in" / "test.nc"
-    assert test_config.as_output_file("test.nc") == tmp_path / "out" / "test.nc"
-    assert test_config.as_intermediate_file("test.nc") == tmp_path / "inter" / "test.nc"
-
     assert test_config.output_file == tmp_path / "out" / "out.nc"
+    assert test_config.static_path == tmp_path / "static"
+    assert test_config.static_path != test_config.input_path
+
+
+def test_prior_config_prepare_paths_creates_static(tmp_path: pathlib.Path, start_date, end_date):
+    static_path = tmp_path / "static"
+    test_config = PriorConfig(
+        domain_path="domain.nc",
+        start_date=start_date,
+        end_date=end_date,
+        input_path=tmp_path / "in",
+        output_path=tmp_path / "out",
+        intermediates_path=tmp_path / "inter",
+        static_path=static_path,
+    )
+
+    assert not test_config.input_path.exists()
+    assert not test_config.intermediates_path.exists()
+    assert not test_config.output_path.exists()
+    assert not test_config.static_path.exists()
+
+    test_config.prepare_paths()
+
+    assert test_config.input_path.exists()
+    assert test_config.intermediates_path.exists()
+    assert test_config.output_path.exists()
+    assert test_config.static_path.exists()
 
 
 def test_prior_config_from_env(reset_env, start_date, end_date):
@@ -82,6 +108,7 @@ def test_prior_config_from_env(reset_env, start_date, end_date):
     os.environ["INPUTS"] = "env/in"
     os.environ["OUTPUTS"] = "env/out"
     os.environ["INTERMEDIATES"] = "env/inter"
+    os.environ["STATIC_INPUTS"] = "env/static"
     os.environ["INPUT_CACHE"] = "env/cache"
     os.environ["OUTPUT_FILENAME"] = "env-output.nc"
 
@@ -94,25 +121,21 @@ def test_prior_config_from_env(reset_env, start_date, end_date):
     assert test_config.input_path == pathlib.Path("env/in")
     assert test_config.output_path == pathlib.Path("env/out")
     assert test_config.intermediates_path == pathlib.Path("env/inter")
+    assert test_config.static_path == pathlib.Path("env/static")
     assert test_config.input_cache == pathlib.Path("env/cache")
     assert test_config.output_filename == "env-output.nc"
 
 
 def test_prior_config_input_cache(tmp_path: pathlib.Path, start_date, end_date):
-    # these settings are required, but unimportant for the test
-    generic_params = dict(
-        domain_path="domain.nc",
-        start_date=start_date,
-        end_date=end_date,
-    )
+    generic_params = dict(domain_path="domain.nc", start_date=start_date)
 
     data_path = tmp_path / "data"
     cache_path = tmp_path / "cache-test"
 
     # created some cached content
-    cache_path.mkdir(parents=True)
+    (cache_path / "inputs").mkdir(parents=True)
     cache_test_contents = f"cache test {datetime.datetime.now()}"
-    with open(cache_path / "cache-test.txt", "w") as cache_test_file:
+    with open(cache_path / "inputs/cache-test.txt", "w") as cache_test_file:
         cache_test_file.write(cache_test_contents)
 
     # create a config with input_cache
@@ -137,14 +160,14 @@ def test_prior_config_input_cache(tmp_path: pathlib.Path, start_date, end_date):
         cache_test_file.write(cache_test_updated)
 
     # the new file is not copied to the cache yet
-    assert not (cache_path / "cache-update.txt").exists()
+    assert not (cache_path / "inputs/cache-update.txt").exists()
 
     # reassign the variable to trigger the PriorConfig deconstructor
     test_config.cache_inputs()
 
     # updated inputs are copied back to the cache
-    assert (cache_path / "cache-update.txt").exists()
-    with open(cache_path / "cache-update.txt") as input_file:
+    assert (cache_path / "inputs/cache-update.txt").exists()
+    with open(cache_path / "inputs/cache-update.txt") as input_file:
         assert input_file.read() == cache_test_updated
 
     # create a config with a different input_cache

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -100,6 +100,30 @@ def test_prior_config_prepare_paths_creates_static(tmp_path: pathlib.Path, start
     assert test_config.static_path.exists()
 
 
+def test_prior_config_to_yaml(start_date, end_date):
+    test_config = PriorConfig(
+        domain_path="domain.nc",
+        start_date=start_date,
+        end_date=end_date,
+        input_path=pathlib.Path("data/input"),
+        output_path=pathlib.Path("data/out"),
+        intermediates_path=pathlib.Path("data/inter"),
+        static_path=pathlib.Path("data/in"),
+    )
+
+    assert test_config.to_yaml() == """domain_path: domain.nc
+end_date: 2022-12-08 00:00:00
+input_cache: null
+input_path: data/input
+intermediates_path: data/inter
+output_filename: prior-emissions.nc
+output_path: data/out
+sectors: null
+start_date: 2022-12-07 00:00:00
+static_path: data/in
+"""
+
+
 def test_prior_config_from_env(reset_env, start_date, end_date):
     os.environ["DOMAIN_FILE"] = "env-domain.nc"
     os.environ["START_DATE"] = "2023-01-01"

--- a/tests/unit/test_data_manager/test_manager.py
+++ b/tests/unit/test_data_manager/test_manager.py
@@ -123,6 +123,32 @@ def test_manager_get_asset_parsed(tmp_path, mocker: MockerFixture, config):
     assert test_second_asset is test_asset
 
 
+def test_manager_static_path_default(tmp_path, config):
+    data_path = tmp_path / "data"
+    test_manager = DataManager(data_path=data_path, prior_config=config)
+
+    assert test_manager.static_path == data_path
+
+
+def test_manager_static_path_routing(tmp_path, config):
+    data_path = tmp_path / "dynamic"
+    static_path = tmp_path / "static"
+    test_manager = DataManager(data_path=data_path, prior_config=config, static_path=static_path)
+
+    static_source = test_manager.add_source(DataSource(
+        name="test-static",
+        file_path="static.txt",
+    ))
+    dynamic_source = test_manager.add_source(DataSource(
+        name="test-dynamic",
+        file_path="dynamic.txt",
+        dynamic=True,
+    ))
+
+    assert static_source.asset_path == static_path / "static.txt"
+    assert dynamic_source.asset_path == data_path / "dynamic.txt"
+
+
 def test_manager_get_asset_dependencies(tmp_path, mocker, config):
     data_path = tmp_path / "data"
     child_fetch = mocker.stub(name="child_fetch")

--- a/tests/unit/test_data_manager/test_source.py
+++ b/tests/unit/test_data_manager/test_source.py
@@ -17,6 +17,36 @@ def test_source_file_path(tmp_path, config):
 
     assert configured_data_source.asset_path == tmp_path / "something-else.json"
 
+def test_source_data_path(tmp_path, config):
+    data_path = tmp_path / "dynamic"
+    static_path = tmp_path / "static"
+
+    static_data_source = DataSource(
+        name="test-static",
+        file_path="static.txt",
+    )
+    configured_static = configure_data_source(
+        data_source=static_data_source,
+        prior_config=config,
+        data_path=data_path,
+        static_path=static_path,
+    )
+
+    assert configured_static.asset_path == static_path / "static.txt"
+
+    dynamic_data_source = DataSource(
+        name="test-dynamic",
+        file_path="dynamic.txt",
+        dynamic=True,
+    )
+    configured_dynamic = configure_data_source(
+        data_source=dynamic_data_source,
+        prior_config=config,
+        data_path=data_path,
+        static_path=static_path,
+    )
+    assert configured_dynamic.asset_path == data_path / "dynamic.txt"
+
 def test_source_file_path_absolute(tmp_path, config):
     # file_path provided
     test_data_source = DataSource(
@@ -51,6 +81,28 @@ def test_source_file_path_callable(tmp_path, config):
     configured_data_source = configure_data_source(test_data_source, config, tmp_path)
 
     assert configured_data_source.asset_path == tmp_path / "test-unfccc-codes.nc"
+
+
+def test_source_file_path_callable_dynamic(tmp_path, config):
+    data_path = tmp_path / "dynamic"
+    static_path = tmp_path / "static"
+
+    def file_path_from_name(_self: DataSource, config: PriorConfig):
+        return f"{_self.name}.nc"
+
+    dynamic_data_source = DataSource(
+        name="test-dynamic",
+        file_path=file_path_from_name,
+        dynamic=True,
+    )
+    configured = configure_data_source(
+        data_source=dynamic_data_source,
+        prior_config=config,
+        data_path=data_path,
+        static_path=static_path,
+    )
+
+    assert configured.asset_path == data_path / "test-dynamic.nc"
 
 
 def test_source_fetch_default(tmp_path, config):


### PR DESCRIPTION
## Description

Resolves #178.

This PR adds a new `static_path` PriorConfig option, and an optional `dynamic` flag to DataSource definitions. When a `static_path` is provided, PriorConfig and DataManager will treat the `input_path` as a storage location for dynamic inputs, and `static_path` as a storage location for static (non-dynamic) inputs.

A data source is considered "dynamic" if it may need to be fetched from run to run, or based on parameters such as the period or domain of interest. GFAS is an example of a dynamic data source, as GFAS data is fetched for the specific dates being modelled.

From a software design perspective, it would probably be safer to treat all data sources as dynamic unless otherwise specified, because this would guarantee the data source is fetched on every run. However, most data sources used by the prior are static, and this appears to be the norm in this type of scientific computing. Most data is provided as static files representing a snapshot of data at a point in time which can be interpolated, or files which represent large periods of time, ie yearly intervals. Even data sources which are fetched via API (see the oil and gas sector) are rarely updated, so treating them as static by default is safer than receiving a large update part-way through a run of dailies.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes

One small addition to this PR is writing the PriorConfig into a file in the output folder on success. This is done primarily for reproducability, to make it easier to re-create the conditions that this prior was run under.

This change is included in this PR is because previously all production run inputs were captured in an archive, but moving forward the contents of the STATIC_INPUTS path will sit outside the run folder and so won't be included in the archive. By recording the PriorConfig `static_path` in this file, we'll make it easier to locate the input batch which was used in the prior run.