### PR TITLE
UNFCCC codes from unofficial ANGA API

### DIFF
--- a/changelog/194.improvement.md
+++ b/changelog/194.improvement.md
@@ -1,0 +1,1 @@
+Fetch UNFCCC codes and level names from unofficial ANGA website API

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -67,39 +67,16 @@ To allocate ANGA inventory emissions to prior sectors, we utilise the
 `unfccc_categories` in each sector, which contain UNFCCC CRT category codes,
 like "5" (Waste), "3.B" (Agriculture - Enteric Fermentation). However, the
 [Australian UNFCCC Inventory](#Australian-UNFCCC-Inventory) doesn't include
-category codes, only full names of the UNFCCC categories (some of which are
-not exact from the original definitions).
+category codes, only full names of the UNFCCC category levels (some of which
+don't match official forms exactly).
 
-A mapping from Australia's inventory categories to UNFCCC has been created to
-assist this process. The mapping was created manually by fetching all the
-category names present in the Australian inventory, and assigning the correct
-code to each category.
+A mapping from ANGA inventory "levels" to UNFCCC codes has been created using
+an unofficial ANGA API which is used to power the ANGA website. This is
+necessary because in the past ANGA has made slight changes to level names, and
+has also added and removed categories from the inventory from year to year.
 
-File can be created initially by finding unique categories in the bulk data:
-
-```shell
-curl -s https://greenhouseaccounts.climatechange.gov.au/OData/AR5_ParisInventory_AUSTRALIA \
-  | jq --raw-output '
-    (["UNFCCC_Code", "UNFCCC_Level_1", "UNFCCC_Level_2", "UNFCCC_Level_3", "UNFCCC_Level_4"] | @csv),
-    (
-      .value[]
-      | select(.Gas_Level_0 == "CH4")
-      | ["", .UNFCCC_Level_1, .UNFCCC_Level_2, .UNFCCC_Level_3, .UNFCCC_Level_4]
-      | @csv
-    )
-  ' \
-  | uniq \
-  > UNFCCC-codes.csv
-```
-
-Note: this excludes level 5 categorisation, where codes are sometimes harder to
-identify and prior sectors are unlikely to model categories to this level.
-
-This generates a file with empty values for "UNFCCC_Code" which must then be
-populated manually.
-
-The completed mapping is available in our public data store:
-https://openmethane.s3.amazonaws.com/prior/inputs/UNFCCC-codes-AU.csv
+If this unofficial API changes or becomes inaccessible, we can make the
+generated UNFCCC codes CSV available via our public data store. 
 
 
 ## Safeguard Mechanism Baselines and Emissions

--- a/src/openmethane_prior/data_sources/inventory/data.py
+++ b/src/openmethane_prior/data_sources/inventory/data.py
@@ -17,6 +17,7 @@
 #
 import json
 import pandas as pd
+import urllib.request
 
 from openmethane_prior.lib import (
     DataSource,
@@ -30,9 +31,51 @@ from .inventory import create_inventory_df
 
 logger = logger.get_logger(__name__)
 
+def rows_from_children(tree, parents = None) -> list:
+    rows = []
+    if tree["level"] > 5: # 5 levels is enough detail for us
+        return rows
+
+    levels = [*parents] if parents is not None else []
+    if tree["level"] > 0:
+        code, name = tree["name"].split(" ", 1)
+        levels.append(name)
+        rows.append([code, *levels])
+    for child in tree["children"]:
+        rows += rows_from_children(child, levels)
+    return rows
+
+
+def fetch_unfccc_codes(data_source: ConfiguredDataSource):
+    """Fetch the heirarchy of UNFCCC codes used on the ANGA website, where
+    the UNFCCC codes are displayed along with the same category names used
+    in the API."""
+    with urllib.request.urlopen(data_source.url) as anga_api_defaults:
+        response = json.loads(anga_api_defaults.read().decode())
+        unfccc_tree = response["sectortreeParis"]["Nodes"]
+    unfccc_rows = rows_from_children(unfccc_tree[0])
+    df = pd.DataFrame(
+        data=unfccc_rows,
+        columns=["UNFCCC_Code", "UNFCCC_Level_1", "UNFCCC_Level_2", "UNFCCC_Level_3", "UNFCCC_Level_4", "UNFCCC_Level_5"],
+    )
+    # Levels > 5 are stripped, resulting in duplicates with the same code
+    df.drop_duplicates(subset=["UNFCCC_Code"], keep="first", inplace=True)
+    df.to_csv(data_source.asset_path, index=False)
+    return data_source.asset_path
+
+
+# UNFCCC category codes with detailed level names which match the level names
+# in the ANGA UNFCCC/Paris Inventory dataset. The url and fetch method use an
+# **unofficial and undocumented** API used by the ANGA website to display
+# the UNFCCC category hierarchy. This is necessary because the inventory
+# dataset only includes level name text without UNFCCC codes, and the levels
+# do not match official UNFCCC category text, and are unstable year to year.
+# Source: https://www.greenhouseaccounts.climatechange.gov.au/
 unfccc_codes_data_source = DataSource(
     name="ANGA-UNFCCC-codes",
-    url="https://openmethane.s3.amazonaws.com/prior/inputs/UNFCCC-codes-AU.csv",
+    url="https://www.greenhouseaccounts.climatechange.gov.au/api/Defaults",
+    file_path="ANGA-UNFCCC-codes.csv",
+    fetch=fetch_unfccc_codes,
     parse=parse_csv,
 )
 
@@ -45,7 +88,9 @@ def parse_inventory(data_source: ConfiguredDataSource) -> pd.DataFrame:
         anga_json = json.load(anga_file)
         return create_inventory_df(anga_json["value"], unfccc_df)
 
-
+# Australia's National Greenhouse Accounts emission inventory, broken down by
+# economic sector using UNFCCC sector categories.
+# Source: https://www.greenhouseaccounts.climatechange.gov.au/ -> Datasets and API
 inventory_data_source = DataSource(
     name="ANGA-UNFCCC-inventory",
     url="https://greenhouseaccounts.climatechange.gov.au/OData/AR5_ParisInventory_AUSTRALIA",

--- a/tests/integration/test_inventory_inputs.py
+++ b/tests/integration/test_inventory_inputs.py
@@ -1,8 +1,14 @@
 import datetime
+import json
+import numpy as np
+import pandas as pd
 import pytest
 
-from openmethane_prior.data_sources.inventory.data import inventory_data_source
-from openmethane_prior.data_sources.inventory.inventory import get_sector_emissions_by_code
+from openmethane_prior.data_sources.inventory import (
+    inventory_data_source,
+    unfccc_codes_data_source,
+    get_sector_emissions_by_code,
+)
 from openmethane_prior.sectors import all_sectors
 
 
@@ -53,3 +59,37 @@ def test_inventory_get_sector_emissions_by_code(all_sector_meta, inventory_df):
 
     # emissions for a shorter period should be scaled from the annual emissions
     assert monthly_coal_emissions == pytest.approx(expected_annual_emissions["coal"] * (31 / 365))
+
+
+def test_inventory_unfccc_codes(input_files, data_manager):
+    unfccc_df = data_manager.get_asset(unfccc_codes_data_source).data
+    inventory_da = data_manager.get_asset(inventory_data_source)
+
+    # extract the raw, unmodified inventory values
+    with open(inventory_da.path) as anga_file:
+        inventory_json = json.load(anga_file)
+        inventory_raw = pd.DataFrame.from_records(
+            inventory_json["value"],
+            columns=[
+                "InventoryYear_ID",
+                "UNFCCC_Level_1", "UNFCCC_Level_2", "UNFCCC_Level_3", "UNFCCC_Level_4",
+                "Gas_Level_0",
+                "Gg",
+            ],
+        )
+
+    inventory_raw_ch4 = inventory_raw[inventory_raw["Gas_Level_0"] == "CH4"]
+    inventory_df = inventory_da.data
+
+    # ensure no inventory values have been "lost" during parsing or while
+    # adding UNFCCC codes
+    assert len(inventory_df) == len(inventory_raw_ch4)
+    assert inventory_df["Gg"].sum() == inventory_raw_ch4["Gg"].sum()
+
+    unfccc_df = unfccc_df.replace([np.nan], [None])
+    _LEVEL_COLUMNS = ["UNFCCC_Level_1", "UNFCCC_Level_2", "UNFCCC_Level_3", "UNFCCC_Level_4"]
+    for inx, row in inventory_df.iterrows():
+        unfccc_row = unfccc_df[unfccc_df["UNFCCC_Code"] == row["UNFCCC_Code"]]
+
+        assert len(unfccc_row) == 1, f"Too many matches for code {row['UNFCCC_Code']}"
+        assert (row[_LEVEL_COLUMNS].values == unfccc_row.iloc[0][_LEVEL_COLUMNS].values).all()


### PR DESCRIPTION
## Description

Recently we discovered that the recent publication of the FY 2023-24 ANGA inventory included some changes to level names of some sectors, and removal of some previously available sectors. This led to our manually created UNFCCC codes CSV to be out of date in a way that was hard to detect.

Instead of manually cross-referencing and fixing the UNFCCC codes CSV, we looked at how the inventory sectors are displayed on the ANGA website where the level names match exactly the levels in the inventory dataset. The website uses an undocumented, unofficial API which includes the "Paris inventory" sector hierarchy used to select sectors in the interactive inventory screen.

By fetching and parsing this API, we can build a list of UNFCCC codes which exactly match the level names present in the ANGA inventory. This only needs to be generated once and then it can be added to the public data store. Alternately, assuming the unofficial API remains available, fetching the codes at the same time the inventory is fetched should guarantee that level names in both datasets always match.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
