### PR TITLE
Fix `fetch_domain` not working with file paths

### DIFF
--- a/changelog/195.fix.md
+++ b/changelog/195.fix.md
@@ -1,0 +1,1 @@
+Fix prior failing when DOMAIN_PATH is a file path

--- a/src/openmethane_prior/lib/config.py
+++ b/src/openmethane_prior/lib/config.py
@@ -178,10 +178,14 @@ def fetch_domain(
 ) -> pathlib.Path:
     domain_path = input_path / os.path.basename(str(path_or_url))
     if not os.path.exists(domain_path):
-        save_path, response = urllib.request.urlretrieve(
-            url=str(path_or_url),
-            filename=domain_path,
-        )
+        as_path = pathlib.Path(path_or_url)
+        if as_path.is_file():
+            domain_path.hardlink_to(as_path)
+        else:
+            save_path, response = urllib.request.urlretrieve(
+                url=str(path_or_url),
+                filename=domain_path,
+            )
     return domain_path
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 import pytest
 
-from openmethane_prior.lib.config import PriorConfig
+from openmethane_prior.lib.config import PriorConfig, fetch_domain
 
 
 # This fixture will allow each test to setup the required env variables and
@@ -203,3 +203,89 @@ def test_prior_config_input_cache(tmp_path: pathlib.Path, start_date, end_date):
 
     # the file from the cache is NOT copied
     assert not (test_config.input_path / "cache-test.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# fetch_domain tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def input_path(tmp_path):
+    path = tmp_path / "inputs"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture()
+def mock_retrieve(mocker):
+    return mocker.patch("urllib.request.urlretrieve")
+
+
+def test_fetch_domain_returns_path_under_input_path(input_path, mock_retrieve):
+    """Returned path is always input_path / basename(path_or_url)."""
+    mock_retrieve.return_value = (str(input_path / "domain.nc"), None)
+    result = fetch_domain("https://example.com/some/nested/domain.nc", input_path)
+    assert result == input_path / "domain.nc"
+
+
+def test_fetch_domain_downloads_url_when_file_missing(input_path, mock_retrieve):
+    """Calls urlretrieve with the URL and destination path when file is absent."""
+    url = "https://example.com/domain.nc"
+    expected_dest = input_path / "domain.nc"
+    mock_retrieve.return_value = (str(expected_dest), None)
+
+    fetch_domain(url, input_path)
+
+    mock_retrieve.assert_called_once_with(url=url, filename=expected_dest)
+
+
+def test_fetch_domain_skips_download_when_file_exists(input_path, mock_retrieve):
+    """Does not call urlretrieve when the destination file already exists."""
+    (input_path / "domain.nc").touch()
+
+    result = fetch_domain("https://example.com/domain.nc", input_path)
+
+    mock_retrieve.assert_not_called()
+    assert result == input_path / "domain.nc"
+
+
+def test_fetch_domain_uses_basename_of_url(input_path, mock_retrieve):
+    """Only the basename of a URL with path segments is used as the filename."""
+    url = "https://example.com/v1/au-test/my-domain-file.nc"
+    expected_dest = input_path / "my-domain-file.nc"
+    mock_retrieve.return_value = (str(expected_dest), None)
+
+    result = fetch_domain(url, input_path)
+
+    assert result.name == "my-domain-file.nc"
+    mock_retrieve.assert_called_once_with(url=url, filename=expected_dest)
+
+
+def test_fetch_domain_hardlinks_local_file(input_path, mock_retrieve):
+    """Creates a hard link in input_path when given a path to an existing local file."""
+    source = input_path.parent / "source" / "domain.nc"
+    source.parent.mkdir()
+    source.write_text("domain content")
+
+    result = fetch_domain(str(source), input_path)
+
+    mock_retrieve.assert_not_called()
+    assert result == input_path / "domain.nc"
+    assert result.exists()
+    assert result.read_text() == "domain content"
+
+
+def test_fetch_domain_skips_hardlink_when_dest_exists(input_path, mocker, mock_retrieve):
+    """Does not create a hard link when the destination already exists."""
+    source = input_path.parent / "source" / "domain.nc"
+    source.parent.mkdir()
+    source.write_text("source content")
+
+    existing = input_path / "domain.nc"
+    existing.write_text("existing content")
+
+    mock_hardlink = mocker.patch.object(pathlib.Path, "hardlink_to")
+    result = fetch_domain(str(source), input_path)
+
+    mock_hardlink.assert_not_called()
+    assert result.read_text() == "existing content"


### PR DESCRIPTION
## Description

The DOMAIN_PATH env variable must work with URLs or local paths, but in it's current iteration local paths are not supported. This change checks if the provided domain is a file path, and copies it (via hardlink) into the correct location if so.

The docs for urllib's urlretrieve state that the function works with local file paths, but I misunderstood this to mean that a file path could be supplied as the url parameter, which is not the case. My local testing didn't catch this because I was using INPUT_CACHE locally, which was copying the domain file into the inputs folder ahead of each test run.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
