### PR TITLE
Fix NaN and masked cells in prior output

### DIFF
--- a/changelog/198.fix.md
+++ b/changelog/198.fix.md
@@ -1,0 +1,1 @@
+Ensure output doesn't include NaN values or MaskedArrays

--- a/src/openmethane_prior/lib/outputs.py
+++ b/src/openmethane_prior/lib/outputs.py
@@ -161,6 +161,15 @@ def add_sector(
             data=expand_sector_dims(sector_data, prior_ds.sizes["time"]),
         )
 
+    # Convert masked arrays and NaN values to zero so sector outputs are clean
+    raw = sector_data.values
+    if isinstance(raw, np.ma.MaskedArray):
+        raw = raw.filled(0)
+
+    # Outputs shouldn't include an NaN values, replace NaN with zeroes
+    raw = np.nan_to_num(raw, nan=0.0)
+    sector_data = sector_data.copy(data=raw)
+
     # enable compression for layer data variables
     sector_data.encoding["zlib"] = True
 

--- a/src/openmethane_prior/lib/regrid.py
+++ b/src/openmethane_prior/lib/regrid.py
@@ -185,6 +185,7 @@ def regrid_data_array_conservative(
     leading_shape = values.shape[:-2]
 
     flat = values.reshape(-1, n_lat * n_lon)
+    flat = np.nan_to_num(flat, nan=0.0)
     regridded = (W @ flat.T).T.reshape(*leading_shape, *domain_grid.shape)
 
     leading_coords = {d: data_da[d].values for d in leading_dims if d in data_da.coords}

--- a/tests/unit/test_lib_regrid.py
+++ b/tests/unit/test_lib_regrid.py
@@ -119,3 +119,27 @@ def test_mass_conservation(domain_grid, source_da, tmp_path):
     total_out = float((result.values * domain_grid.cell_area).sum())
 
     np.testing.assert_allclose(total_out, total_in, rtol=0.005)
+
+
+def test_nan_source_cells_not_propagated(domain_grid, source_da, tmp_path):
+    # Domain cell (y=0, x=0) covers lon 138–140, lat –38 to –36 and intersects
+    # four 1° source cells. Setting one of them to NaN must not make the domain
+    # cell NaN — the remaining three concrete cells should still contribute.
+    da_with_nan = source_da.copy(deep=True)
+    da_with_nan.values[0, 0] = np.nan  # lat –37.5, lon 138.5
+
+    result = regrid_data_array_conservative(da_with_nan, domain_grid, tmp_path, "tnan")
+
+    assert np.isfinite(result.values[0, 0]), (
+        "Domain cell overlapping a NaN source cell must not itself become NaN "
+        "when other intersecting source cells have concrete values."
+    )
+
+    # Run the same test with a zero in the cell which had np.nan, the results
+    # should be identical
+    da_with_zero = source_da.copy(deep=True)
+    da_with_zero.values[0, 0] = 0  # same coords as da_with_nan nan value
+
+    result_clean = regrid_data_array_conservative(da_with_zero, domain_grid, tmp_path, "tnan_clean")
+
+    np.testing.assert_array_equal(result, result_clean)

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -6,6 +6,15 @@ from openmethane_prior.lib.outputs import create_output_dataset, expand_sector_d
 from openmethane_prior.lib.sector.sector import PriorSector
 
 
+def create_mock_prior_sector(**kwargs) -> PriorSector:
+    """Return a minimal PriorSector for use in tests, with overridable fields."""
+    defaults = dict(
+        name="test_sector",
+        emission_category="natural",
+        create_estimate=lambda a, b, c: None,
+    )
+    return PriorSector(**(defaults | kwargs))
+
 
 def test_create_output_dataset(config, input_files):
     domain_ds = config.domain().dataset
@@ -127,11 +136,7 @@ def test_expand_sector_dims_add_time_steps():
 def test_add_sector_defaults(config, input_files):
     test_ds = create_output_dataset(config)
 
-    sector_meta = PriorSector(
-        name="test_sector",
-        emission_category="natural",
-        create_estimate=lambda a, b, c: None
-    )
+    sector_meta = create_mock_prior_sector()
     sector_shape = (test_ds.sizes["time"], 1, config.domain().grid.shape[0], config.domain().grid.shape[1])
     sector_data = np.zeros(sector_shape)
 
@@ -158,13 +163,11 @@ def test_add_sector_defaults(config, input_files):
 def test_add_sector_meta(config, input_files):
     test_ds = create_output_dataset(config)
 
-    sector_meta = PriorSector(
-        name="test_sector",
+    sector_meta = create_mock_prior_sector(
         emission_category="anthropogenic",
         unfccc_categories=["1.A"],
         cf_standard_name="standard_name_suffix",
         cf_long_name="test long name",
-        create_estimate=lambda a, b, c: None
     )
     sector_shape = (test_ds.sizes["time"], 1, config.domain().grid.shape[0], config.domain().grid.shape[1])
     sector_data = np.zeros(sector_shape)
@@ -194,11 +197,7 @@ def test_add_sector_masked_dataarray(config, input_files):
     """A DataArray created from a masked array should have masked cells stored as zero, not NaN."""
     test_ds = create_output_dataset(config)
 
-    sector_meta = PriorSector(
-        name="test_sector",
-        emission_category="natural",
-        create_estimate=lambda a, b, c: None,
-    )
+    sector_meta = create_mock_prior_sector()
     grid_y, grid_x = config.domain().grid.shape
 
     raw = np.ones((grid_y, grid_x))
@@ -222,11 +221,7 @@ def test_add_sector_nan_values(config, input_files):
     """NaN values in sector data should be replaced with zero in the output."""
     test_ds = create_output_dataset(config)
 
-    sector_meta = PriorSector(
-        name="test_sector",
-        emission_category="natural",
-        create_estimate=lambda a, b, c: None,
-    )
+    sector_meta = create_mock_prior_sector()
     grid_y, grid_x = config.domain().grid.shape
 
     raw = np.ones((grid_y, grid_x))

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -188,3 +188,56 @@ def test_add_sector_meta(config, input_files):
     assert test_ds[sector_var].attrs["emission_category"] == "anthropogenic"
     assert test_ds[sector_var].attrs["units"] == "kg/m2/s"
     assert test_ds[sector_var].attrs["grid_mapping"] == test_ds["land_mask"].attrs["grid_mapping"]
+
+
+def test_add_sector_masked_dataarray(config, input_files):
+    """A DataArray created from a masked array should have masked cells stored as zero, not NaN."""
+    test_ds = create_output_dataset(config)
+
+    sector_meta = PriorSector(
+        name="test_sector",
+        emission_category="natural",
+        create_estimate=lambda a, b, c: None,
+    )
+    grid_y, grid_x = config.domain().grid.shape
+
+    raw = np.ones((grid_y, grid_x))
+    mask = np.zeros((grid_y, grid_x), dtype=bool)
+    mask[0, 0] = True  # mask the top-left cell
+    # xarray converts masked values to NaN internally; add_sector must then replace them with zero
+    sector_data = xr.DataArray(data=np.ma.MaskedArray(raw, mask=mask), dims=["y", "x"])
+
+    add_sector(prior_ds=test_ds, sector_data=sector_data, sector_meta=sector_meta)
+
+    sector_var = f"ch4_sector_{sector_meta.name}"
+    result = test_ds[sector_var]
+
+    assert not isinstance(result.values, np.ma.MaskedArray), "output must not be a masked array"
+    assert not np.isnan(result.values).any(), "output must not contain NaN values"
+    assert (result.values[:, :, 0, 0] == 0.0).all(), "masked cells must be replaced with zero"
+    assert (result.values[:, :, 0, 1] == 1.0).all(), "unmasked cells must retain their value"
+
+
+def test_add_sector_nan_values(config, input_files):
+    """NaN values in sector data should be replaced with zero in the output."""
+    test_ds = create_output_dataset(config)
+
+    sector_meta = PriorSector(
+        name="test_sector",
+        emission_category="natural",
+        create_estimate=lambda a, b, c: None,
+    )
+    grid_y, grid_x = config.domain().grid.shape
+
+    raw = np.ones((grid_y, grid_x))
+    raw[0, 0] = np.nan  # inject NaN into the top-left cell
+    sector_data = xr.DataArray(data=raw, dims=["y", "x"])
+
+    add_sector(prior_ds=test_ds, sector_data=sector_data, sector_meta=sector_meta)
+
+    sector_var = f"ch4_sector_{sector_meta.name}"
+    result = test_ds[sector_var]
+
+    assert not np.isnan(result.values).any(), "output must not contain NaN values"
+    assert (result.values[:, :, 0, 0] == 0.0).all(), "NaN cells must be replaced with zero"
+    assert (result.values[:, :, 0, 1] == 1.0).all(), "non-NaN cells must retain their value"


### PR DESCRIPTION
## Description

Ever since updating the output format for the prior, output has included cells with NaN values in certain sectors, which are propagated into the final `ch4_total` output variable. Additionally, since some sectors are based on NetCDF inputs, some sector outputs ended up being MaskedArrays which was unintentional.

This PR sanitises sector data before adding it to the output in the `add_sector` method, ensuring output is in a predictable, intentional format.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes

Technically, converting NaN values to zero is actually losing information, the difference between zero emissions and lack of data. However, our purpose is to provide emission estimates across all of Australia, and some downstream uses (such as CMAQ) require a numeric value for each cell.

If we decide it's important to provide more transparency about lack of data, we believe the best way to handle this in the future is by including uncertainty values, which will be quite high for cells which originate from NaN values.