### PR TITLE
Prevent docker build and push workflow on PRs from external repos

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -16,7 +16,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    # prevent workflow running on external PRs
+    if: github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       matrix:
         platform:

--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -16,8 +16,10 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # prevent workflow running on external PRs
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # prevent workflow running on external PRs, but build on any push or PR
+    # to the official repo.
+    if: github.event.push.repository.full_name == 'openmethane/openmethane-prior'
+      || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       matrix:
         platform:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,11 +36,18 @@ jobs:
           curl -L -o data/.cache/inputs/gfas_2022-12-07_2022-12-08.nc "https://openmethane.s3.amazonaws.com/tests/gfas/gfas_2022-12-07_2022-12-08.nc"
       - name: Run tests
         run: |
-          make test
+          uv run python -m pytest -r a -v tests -k "not test_cdsapi_connection"
         env:
-#          CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
-#          CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api
           INPUT_CACHE: data/.cache
+      # Run tests which require GitHub Actions secrets only on internal PRs and merges
+      - name: Run tests with credentials
+        if: github.event.push.repository.full_name == 'openmethane/openmethane-prior'
+          || github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          uv run python -m pytest -r a -v tests -k "test_cdsapi_connection"
+        env:
+          CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
+          CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api
 
   check-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,12 +29,17 @@ jobs:
         with:
           path: data/.cache
           key: test-data-cache
+      # Fetch GFAS data from public data store so ADS credentials aren't needed
+      - name: Fetch GFAS test data
+        run: |
+          mkdir -p data/.cache/inputs
+          curl -L -o data/.cache/inputs/gfas_2022-12-07_2022-12-08.nc "https://openmethane.s3.amazonaws.com/tests/gfas/gfas_2022-12-07_2022-12-08.nc"
       - name: Run tests
         run: |
           make test
         env:
-          CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
-          CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api
+#          CDSAPI_KEY: ${{ secrets.CDSAPI_ADS_KEY }}
+#          CDSAPI_URL: https://ads.atmosphere.copernicus.eu/api
           INPUT_CACHE: data/.cache
 
   check-build:

--- a/changelog/202.improvement.md
+++ b/changelog/202.improvement.md
@@ -1,0 +1,1 @@
+Only runs tests and actions which need credentials for internal PRs and pushes

--- a/tests/integration/test_sector_fire/test_sector_fire.py
+++ b/tests/integration/test_sector_fire/test_sector_fire.py
@@ -5,10 +5,15 @@ from openmethane_prior.lib import create_prior
 from openmethane_prior.sectors.fire import gfas_data_source, sector
 
 
-@pytest.mark.skip(reason="Duplicated by test_sector_fire")
-def test_cdsapi_connection(tmp_path, data_manager):
+def test_cdsapi_connection(tmp_path, data_manager, start_date, end_date):
+    """Test fetching GFAS data from the authenticated Copernicus ADS service.
+    Note that this requires valid ADS credentials to be present."""
+    expected_path = data_manager.data_path / f"gfas_{start_date.strftime('%Y-%m-%d')}_{end_date.strftime('%Y-%m-%d')}.nc"
+    assert not os.path.exists(expected_path)
+
     gfas_asset = data_manager.get_asset(gfas_data_source)
 
+    assert gfas_asset.path == expected_path
     assert os.path.exists(gfas_asset.path)
 
 


### PR DESCRIPTION
## Description

Resolves #201.

This change prevents the `build` job from running in the `build_docker` GitHub Actions workflow, when the workflow trigger is a pull request from an external repo.

Preventing the `build` job from running also prevents the rest of the jobs in the workflow, which depend on `build`.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
