### PR TITLE
Fix external PR checks in GitHub Actions

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     # prevent workflow running on external PRs, but build on any push or PR
     # to the official repo.
-    if: '!github.event.push.repository.fork'
+    if: '!github.event.push.repository.fork && !github.event.pull_request.head.repo.fork'
     strategy:
       matrix:
         platform:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           INPUT_CACHE: data/.cache
       # Run tests which require GitHub Actions secrets only on internal PRs and merges
       - name: Run tests with credentials
-        if: '!github.event.push.repository.fork'
+        if: '!github.event.push.repository.fork && !github.event.pull_request.head.repo.fork'
         run: |
           uv run python -m pytest -r a -v tests -k "test_cdsapi_connection"
         env:

--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ uv sync
 ### Input Data
 
 Input data will be downloaded on-demand by the layers that use it while running
-omPrior.py. To inspect where data is fetched from, look for instances of
-`DataSource` defined in each layer.
+omPrior.py. The downloaded files will be stored in the path specified in
+`INPUTS` environment variable (`data/inputs` by default), and `STATIC_INPUTS`
+if specified.
 
-The downloaded files will be stored in the path specified in `INPUTS` env var
-(`data/inputs` by default).
+Data sources are documented in (docs/data-sources.md)[docs/data-sources.md]. To
+inspect where data is fetched from in more detail, look for instances of
+`DataSource` defined in each layer.
 
 ### Domain Info
 


### PR DESCRIPTION
## Description

External PR for testing checks that prevent GitHub Actions from running when no credentials will be available.

Small update to README.md clarifying where data assets will be downloaded, and provide a link to `docs/data-sources.md`  where more detail is available.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`

## Notes
