### PR TITLE
Remove NT well filtering by `PURPOSE` which is no longer available

### DIFF
--- a/changelog/207.fix.md
+++ b/changelog/207.fix.md
@@ -1,0 +1,1 @@
+Remove NT oil well filtering based on the PURPOSE field which no longer contains accurate data

--- a/src/openmethane_prior/sectors/oil_gas/emission_sources/nt_sources.py
+++ b/src/openmethane_prior/sectors/oil_gas/emission_sources/nt_sources.py
@@ -35,10 +35,6 @@ def nt_emission_sources(
     nt_wells_df: gpd.GeoDataFrame = nt_wells_da.data
     nt_titles_df: gpd.GeoDataFrame = nt_titles_da.data
 
-    # filter out non-production wells
-    emitting_well_purposes = ["Development", "Production"]
-    nt_wells_df = nt_wells_df[nt_wells_df["PURPOSE"].isin(emitting_well_purposes)]
-
     # well datasets may have duplicate rows for a single location due to
     # further drilling at a site to deepen/extend an existing hole
     nt_wells_df = nt_wells_df.sort_values(by="DT_RELEASE")

--- a/tests/integration/test_sector_oil_gas/test_emission_sources.py
+++ b/tests/integration/test_sector_oil_gas/test_emission_sources.py
@@ -76,8 +76,8 @@ def test_nt_emission_sources(input_files, data_manager):
     # no sources where activity period doesn't intersect date period
     assert len(df[(df["activity_end"] < start_date) & (df["activity_start"] > start_date_end)]) == 0
 
-    # no sources which aren't related to production
-    assert set(df["PURPOSE"].unique()) == {"Production", "Development"}
+    # well purposes are no longer reported in the public dataset
+    assert set(df["PURPOSE"].unique()) == {"NR"}
 
     # no duplicate entries for the same location
     assert len(df["geometry"].unique()) == len(df)

--- a/tests/integration/test_sector_oil_gas/test_emission_sources.py
+++ b/tests/integration/test_sector_oil_gas/test_emission_sources.py
@@ -76,9 +76,6 @@ def test_nt_emission_sources(input_files, data_manager):
     # no sources where activity period doesn't intersect date period
     assert len(df[(df["activity_end"] < start_date) & (df["activity_start"] > start_date_end)]) == 0
 
-    # well purposes are no longer reported in the public dataset
-    assert set(df["PURPOSE"].unique()) == {"NR"}
-
     # no duplicate entries for the same location
     assert len(df["geometry"].unique()) == len(df)
 


### PR DESCRIPTION

## Description

A recent update to the NT Petroleum Wells dataset has replaced the PURPOSE for every well with "NR", making it useless for us to filter by.

The [metadata](https://www.ntlis.nt.gov.au/metadata/export_data?type=html&metadata_id=2DBCB771210D06B6E040CD9B0F274EFE) for this dataset still lists the Purpose field with the values we previously saw and used for filtering, but the data is missing from the actual dataset.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes

I've raised an enquiry with the NT geoscience email address to understand whether this change was intentional. If this data is intentionally removed/hidden then this PR will have to be merged as a permanent change. If it turns out that the data was removed accidentally / temporarily, we should probably merge this in the short term so that the prior continues to function, but plan to revert the change later.
