### PR TITLE
Revert "Remove NT well filtering by PURPOSE"

### DIFF
--- a/changelog/209.fix.md
+++ b/changelog/209.fix.md
@@ -1,0 +1,1 @@
+Restore NT oil well filtering based on the PURPOSE field

--- a/src/openmethane_prior/sectors/oil_gas/emission_sources/nt_sources.py
+++ b/src/openmethane_prior/sectors/oil_gas/emission_sources/nt_sources.py
@@ -35,6 +35,10 @@ def nt_emission_sources(
     nt_wells_df: gpd.GeoDataFrame = nt_wells_da.data
     nt_titles_df: gpd.GeoDataFrame = nt_titles_da.data
 
+    # filter out non-production wells
+    emitting_well_purposes = ["Development", "Production"]
+    nt_wells_df = nt_wells_df[nt_wells_df["PURPOSE"].isin(emitting_well_purposes)]
+
     # well datasets may have duplicate rows for a single location due to
     # further drilling at a site to deepen/extend an existing hole
     nt_wells_df = nt_wells_df.sort_values(by="DT_RELEASE")

--- a/tests/integration/test_sector_oil_gas/test_emission_sources.py
+++ b/tests/integration/test_sector_oil_gas/test_emission_sources.py
@@ -76,6 +76,9 @@ def test_nt_emission_sources(input_files, data_manager):
     # no sources where activity period doesn't intersect date period
     assert len(df[(df["activity_end"] < start_date) & (df["activity_start"] > start_date_end)]) == 0
 
+    # no sources which aren't related to production
+    assert set(df["PURPOSE"].unique()) == {"Production", "Development"}
+
     # no duplicate entries for the same location
     assert len(df["geometry"].unique()) == len(df)
 


### PR DESCRIPTION
## Description

This reverts PR #207, which addressed a change in NT petroleum well data that turned out to be a temporary bug, not a permanent change.

To quote the NT Department of Mining and Energy:

> Thanks for informing us about this issue. We use FME to join data from database and an excel files. Recently we switched the Data Storage and Backup System. The reader from FME should adapt it automatically, but it didn’t. I reimported them and it will go to production as soon as possible.

The restored data is now available in production.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

## Notes
